### PR TITLE
Swap hotfix

### DIFF
--- a/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
+++ b/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
@@ -42,7 +42,7 @@ WITH v3_pools AS ( -- uni v3
       REGEXP_REPLACE(p.event_inputs:pair,'\"','')   as pool_address, 
       REGEXP_REPLACE(p.event_inputs:token0,'\"','') as token0,
       REGEXP_REPLACE(p.event_inputs:token1,'\"','') as token1,
-      'uniswap-v2' AS platform
+      CASE WHEN factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform
     FROM {{ source('ethereum', 'ethereum_events_emitted') }} p -- {{ref('ethereum__events_emitted')}} p
 
     LEFT JOIN {{source('ethereum','ethereum_contracts')}} a ON REGEXP_REPLACE(p.event_inputs:token0,'\"','') = a.address

--- a/models/ethereum/dex/ethereum__dex_swaps.sql
+++ b/models/ethereum/dex/ethereum__dex_swaps.sql
@@ -25,7 +25,9 @@ WITH usd_swaps AS (
     event_inputs:amount0Out / POWER(10, price0.decimals) AS amount_out, 
     REGEXP_REPLACE(event_inputs:sender,'\"','') AS from_address,
     REGEXP_REPLACE(event_inputs:to,'\"','') AS to_address,
-    event_inputs:amount0In * price0.price / POWER(10, price0.decimals) AS amount_usd,
+    CASE WHEN event_inputs:amount0In > 0 THEN event_inputs:amount0In * price0.price / POWER(10, price0.decimals) 
+         ELSE event_inputs:amount0Out * price0.price / POWER(10, price0.decimals) END
+    AS amount_usd,
     'uniswap-v2' AS platform
   FROM {{ref('ethereum__events_emitted')}} s0
 
@@ -55,7 +57,9 @@ WITH usd_swaps AS (
     event_inputs:amount1Out / POWER(10, price1.decimals) AS amount_out, 
     REGEXP_REPLACE(event_inputs:sender,'\"','') AS from_address,
     REGEXP_REPLACE(event_inputs:to,'\"','') AS to_address,
-    event_inputs:amount1In * price1.price / POWER(10, price1.decimals) AS amount_usd,
+    CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, price1.decimals) 
+         ELSE event_inputs:amount1Out * price1.price / POWER(10, price1.decimals) END
+    AS amount_usd,
     'uniswap-v2' AS platform
   FROM  {{ref('ethereum__events_emitted')}} s0
 

--- a/models/ethereum/dex/ethereum__dex_swaps.sql
+++ b/models/ethereum/dex/ethereum__dex_swaps.sql
@@ -28,7 +28,7 @@ WITH usd_swaps AS (
     CASE WHEN event_inputs:amount0In > 0 THEN event_inputs:amount0In * price0.price / POWER(10, price0.decimals) 
          ELSE event_inputs:amount0Out * price0.price / POWER(10, price0.decimals) END
     AS amount_usd,
-    'uniswap-v2' AS platform
+    CASE WHEN p.factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform
   FROM {{ref('ethereum__events_emitted')}} s0
 
   LEFT JOIN {{ref('ethereum__dex_liquidity_pools')}} p 
@@ -60,7 +60,7 @@ WITH usd_swaps AS (
     CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, price1.decimals) 
          ELSE event_inputs:amount1Out * price1.price / POWER(10, price1.decimals) END
     AS amount_usd,
-    'uniswap-v2' AS platform
+    CASE WHEN p.factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform
   FROM  {{ref('ethereum__events_emitted')}} s0
 
   LEFT JOIN {{ref('ethereum__dex_liquidity_pools')}} p 


### PR DESCRIPTION
Quick fixes for two things

1) Correct USD amounts weren't showing up for certain swaps depending on the direction of the swap (amountIn/amountOut columns). Now fixed

2) Sushiswap and Uniswap both used the same platform but have different factory contracts. Adjusted the platform name to `sushiswap` and `uniswap-v2` (this one should require a full refresh to set the new platform labels up correctly for past swaps/pools!)