### PR TITLE
udm_events ethereum

### DIFF
--- a/models/sources.yml
+++ b/models/sources.yml
@@ -32,6 +32,7 @@ sources:
       - name: ethereum_token_contracts
       - name: sha256_function_signatures
       - name: nft_metadata
+      - name: udm_events_ethereum
   - name: flow
     schema: silver
     tables:


### PR DESCRIPTION
*Part 1/2 of udm-events for ethereum on DOOR*
uses new prices_v2 and asset metadata tables, adding decimals using `ethereum_contract_decimal_adjustments`