### PR TITLE
Add old pools

### DIFF
--- a/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
+++ b/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
@@ -81,8 +81,8 @@ WITH v3_pools AS ( -- uni v3
       ---- if the above is null, try cmc_assets
       ---- if the above is null, try to at least get a name instead of a symbol from ethereum_address_labels
       ---- if all else fails then just use the token contract address to yield an informative name
-      COALESCE(a.meta:symbol,aa.symbol,aaa.address_name,p.event_inputs:token0) ||'-'||COALESCE(b.meta:symbol,bb.symbol,bbb.address_name,p.event_inputs:token1)||' LP' AS pool_name,
-      REGEXP_REPLACE(p.event_inputs:pair,'\"','')   as pool_address, 
+      COALESCE(a.meta:symbol,aa.symbol,aaa.address_name,p.token0) ||'-'||COALESCE(b.meta:symbol,bb.symbol,bbb.address_name,p.token1)||' LP' AS pool_name,
+      pair   as pool_address, 
       token0,
       token1,
       CASE WHEN factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform
@@ -106,12 +106,13 @@ WITH v3_pools AS ( -- uni v3
     LEFT JOIN {{source('ethereum', 'ethereum_address_labels')}} bbb 
       ON token1 = bbb.address
 
-    WHERE p.event_name    = 'PairCreated'
-    {% if is_incremental() %}
-      AND block_timestamp >= getdate() - interval '2 days'
-    {% else %}
-      AND block_timestamp >= getdate() - interval '12 months'
-    {% endif %}
+    -- WHERE 
+    -- p.event_name    = 'PairCreated'
+    -- {% if is_incremental() %}
+    --  block_timestamp >= getdate() - interval '2 days'
+    -- {% else %}
+    --  AND block_timestamp >= getdate() - interval '12 months'
+    -- {% endif %}
 
 ), stack AS (
   -- get pool info 

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -15,6 +15,7 @@ sources:
       - name: udm_balances
       - name: udm_decimal_adjustments
       - name: udm_velocity
+      - name: uniswapv2factory_event_paircreated
   - name: ethereum
     schema: silver
     tables:      


### PR DESCRIPTION
This adds pools from the old prototype table Dan had made

Functionally that table is exactly identical to dex_liquidity_pools, however snowflake currently goes back only as far as October 2020. Since we need pools in dex_liquidity_pools to calculate usd values in dex_swaps, this can cause blank entries on pools created before Oct 2020.

The table Dan created doesn't update and doesn't go up to present day - but it does cover the gap period between October 2020 and the launch of v2. So it had made sense to just merge it into the existing table to cover the blindspot

So for instance https://v2.info.uniswap.org/pair/0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc (which also accounts for a good amount of uniswap v2 volume) now gets included. (Tested by running it on the dev database and data should still be there)