### PR TITLE
adding additional sushi pools from older than the ethereum data currently goes

### DIFF
--- a/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
+++ b/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
@@ -114,7 +114,78 @@ WITH v3_pools AS ( -- uni v3
     --  AND block_timestamp >= getdate() - interval '12 months'
     -- {% endif %}
 
-), stack AS (
+), sushi_write_in AS (
+  -- adding a few major sushi pools that were created before we have eth data (this gives us data on swaps with these pools)
+  SELECT  
+        NULL AS creation_time,
+        NULL AS creation_tx,
+        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
+        'WBTC-ETH SLP' AS pool_name,
+        '0xceff51756c56ceffca006cd410b03ffc46dd3a58' AS pool_address,
+        '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599' AS token0,
+        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token1,
+        'sushiswap' AS platform
+  
+  UNION
+  
+  SELECT  
+        NULL AS creation_time,
+        NULL AS creation_tx,
+        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
+        'SUSHI-ETH SLP' AS pool_name,
+        '0x795065dcc9f64b5614c407a6efdc400da6221fb0' AS pool_address,
+        '0x6b3595068778dd592e39a122f4f5a5cf09c90fe2' AS token0,
+        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token1,
+        'sushiswap' AS platform
+  
+  UNION
+  
+  SELECT  
+        NULL AS creation_time,
+        NULL AS creation_tx,
+        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
+        'USDC-ETH SLP' AS pool_name,
+        '0x397ff1542f962076d0bfe58ea045ffa2d347aca0' AS pool_address,
+        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' AS token0,
+        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token1,
+        'sushiswap' AS platform
+  
+  
+  UNION
+  
+  SELECT  
+        NULL AS creation_time,
+        NULL AS creation_tx,
+        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
+        'ETH-USDT SLP' AS pool_name,
+        '0x06da0fd433c1a5d7a4faa01111c044910a184553' AS pool_address,
+        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token0,
+        '0xdac17f958d2ee523a2206206994597c13d831ec7' AS token1,
+        'sushiswap' AS platform
+    
+  
+  UNION
+  
+  SELECT  
+        NULL AS creation_time,
+        NULL AS creation_tx,
+        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
+        'DAI-ETH SLP' AS pool_name,
+        '0xc3d03e4f041fd4cd388c549ee2a29a9e5075882f' AS pool_address,
+        '0x6b175474e89094c44da98b954eedeac495271d0f' AS token0,
+        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token1,
+        'sushiswap' AS platform
+  
+), new_sushi AS (
+  SELECT s.* -- future proofing: once the eth backfill is done these manual write-ins will be dups
+  FROM sushi_write_in s
+  LEFT JOIN v2_pools v
+  ON s.pool_address = v.pool_address
+  WHERE v.pool_address IS NULL
+),
+
+
+stack AS (
   -- get pool info 
   SELECT * FROM
   v2_pools
@@ -123,6 +194,11 @@ WITH v3_pools AS ( -- uni v3
 
   SELECT * FROM
   v2_redshift
+
+  UNION
+  
+  SELECT * FROM
+  new_sushi
 
   UNION
 


### PR DESCRIPTION
Adding in some sushiswap pools that we might want to use in a bounty question. They were created before the first date we have ethereum data for, so were missing in the dex_liquidity_table and therefore also swaps. This is just a manual write-in (also de-dupped so when we do get data for them we won't have duplicate entries)