### PR TITLE
Fixing amounts v2, last push one fixed decimals but this should account for extreme price swings

### DIFF
--- a/models/ethereum/dex/ethereum__dex_swaps.sql
+++ b/models/ethereum/dex/ethereum__dex_swaps.sql
@@ -55,9 +55,9 @@ WITH decimals_raw as (
     CASE WHEN event_inputs:amount0In > 0 THEN event_inputs:amount0In * price0.price / POWER(10, d0.decimals) 
          ELSE event_inputs:amount0Out * price0.price / POWER(10, d0.decimals) END
     AS amount_usd,
-    CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
-         ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
-    AS other_amount_usd,
+    --CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
+    --     ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
+    --AS other_amount_usd,
     CASE WHEN p.factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform,
     event_index,
     CASE WHEN event_inputs:amount0In > 0 THEN 'IN' 
@@ -73,11 +73,11 @@ WITH decimals_raw as (
   LEFT JOIN decimals d0
     ON p.token0 = d0.token_address
 
-  LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price1
-    ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
+  --LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price1
+  --  ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
 
-  LEFT JOIN decimals d1
-    ON p.token1 = d1.token_address
+  --LEFT JOIN decimals d1
+  --  ON p.token1 = d1.token_address
 
   WHERE event_name = 'Swap' AND platform <> 'uniswap-v3' 
 
@@ -102,9 +102,9 @@ WITH decimals_raw as (
     CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
          ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
     AS amount_usd,
-    CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
-         ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
-    AS other_amount_usd,
+    -- CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
+    --     ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
+    --AS other_amount_usd,
     CASE WHEN p.factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform,
     event_index,
     CASE WHEN event_inputs:amount1In > 0 THEN 'IN' 
@@ -115,14 +115,14 @@ WITH decimals_raw as (
   LEFT JOIN {{ref('ethereum__dex_liquidity_pools')}} p 
     ON s0.contract_address = p.pool_address
 
-  LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price0 
-    ON p.token0 = price0.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
+  --LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price0 
+  --  ON p.token0 = price0.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
 
-  LEFT JOIN decimals d0
-    ON p.token0 = d0.token_address
+  --LEFT JOIN decimals d0
+  --  ON p.token0 = d0.token_address
 
   LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price1
-    ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
+    ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price1.hour
 
   LEFT JOIN decimals d1
     ON p.token1 = d1.token_address
@@ -199,12 +199,14 @@ SELECT
   amount_in,amount_out,
   from_address,
   to_address,
-  CASE WHEN ((amount_usd - other_amount_usd) / amount_usd) > .15 THEN other_amount_usd
-  ELSE amount_usd END AS amount_usd,
+  -- CASE WHEN ((amount_usd - other_amount_usd) / amount_usd) > .15 THEN other_amount_usd
+  -- ELSE amount_usd END AS amount_usd,
+  amount_usd,
   platform,
   event_index,
   direction
 FROM usd_swaps
+WHERE pool_address NOT IN ('0xdc6a5faf34affccc6a00d580ecb3308fc1848f22') -- stop-gap for big price swings, the actual solution adds an enormous amount of runtime
 
 UNION
 

--- a/models/ethereum/dex/ethereum__dex_swaps.sql
+++ b/models/ethereum/dex/ethereum__dex_swaps.sql
@@ -37,7 +37,7 @@ WITH decimals_raw as (
    decimals IS NOT NULL
 
 ), decimals AS (
-  SELECT token_address,decimals
+  SELECT token_address,decimals,weight
   FROM decimals_raw
   QUALIFY (row_number() OVER (partition by token_address order by weight desc)) = 1
 ),
@@ -48,13 +48,16 @@ WITH decimals_raw as (
     p.pool_name,
     p.token0 AS token_address,
     tx_id, 
-    event_inputs:amount0In / POWER(10, d.decimals) AS amount_in,
-    event_inputs:amount0Out / POWER(10, d.decimals) AS amount_out, 
+    event_inputs:amount0In / POWER(10, d0.decimals) AS amount_in,
+    event_inputs:amount0Out / POWER(10, d0.decimals) AS amount_out, 
     REGEXP_REPLACE(event_inputs:sender,'\"','') AS from_address,
     REGEXP_REPLACE(event_inputs:to,'\"','') AS to_address,
-    CASE WHEN event_inputs:amount0In > 0 THEN event_inputs:amount0In * price0.price / POWER(10, d.decimals) 
-         ELSE event_inputs:amount0Out * price0.price / POWER(10, d.decimals) END
+    CASE WHEN event_inputs:amount0In > 0 THEN event_inputs:amount0In * price0.price / POWER(10, d0.decimals) 
+         ELSE event_inputs:amount0Out * price0.price / POWER(10, d0.decimals) END
     AS amount_usd,
+    CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
+         ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
+    AS other_amount_usd,
     CASE WHEN p.factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform,
     event_index,
     CASE WHEN event_inputs:amount0In > 0 THEN 'IN' 
@@ -67,8 +70,14 @@ WITH decimals_raw as (
   LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price0 
     ON p.token0 = price0.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
 
-  LEFT JOIN decimals d
-    ON p.token0 = d.token_address
+  LEFT JOIN decimals d0
+    ON p.token0 = d0.token_address
+
+  LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price1
+    ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
+
+  LEFT JOIN decimals d1
+    ON p.token1 = d1.token_address
 
   WHERE event_name = 'Swap' AND platform <> 'uniswap-v3' 
 
@@ -86,13 +95,16 @@ WITH decimals_raw as (
     p.pool_name,
     p.token1 AS token_address,
     tx_id, 
-    event_inputs:amount1In / POWER(10, d.decimals) AS amount_in,
-    event_inputs:amount1Out / POWER(10, d.decimals) AS amount_out, 
+    event_inputs:amount1In / POWER(10, d1.decimals) AS amount_in,
+    event_inputs:amount1Out / POWER(10, d1.decimals) AS amount_out, 
     REGEXP_REPLACE(event_inputs:sender,'\"','') AS from_address,
     REGEXP_REPLACE(event_inputs:to,'\"','') AS to_address,
-    CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d.decimals) 
-         ELSE event_inputs:amount1Out * price1.price / POWER(10, d.decimals) END
+    CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
+         ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
     AS amount_usd,
+    CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
+         ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
+    AS other_amount_usd,
     CASE WHEN p.factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform,
     event_index,
     CASE WHEN event_inputs:amount1In > 0 THEN 'IN' 
@@ -103,12 +115,18 @@ WITH decimals_raw as (
   LEFT JOIN {{ref('ethereum__dex_liquidity_pools')}} p 
     ON s0.contract_address = p.pool_address
 
-  LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price1 
-    ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price1.hour
+  LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price0 
+    ON p.token0 = price0.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
 
-  LEFT JOIN decimals d
-    ON p.token1 = d.token_address
-    
+  LEFT JOIN decimals d0
+    ON p.token0 = d0.token_address
+
+  LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price1
+    ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
+
+  LEFT JOIN decimals d1
+    ON p.token1 = d1.token_address
+  
 
   WHERE 
       event_name = 'Swap' AND platform <> 'uniswap-v3' 
@@ -173,7 +191,19 @@ WITH decimals_raw as (
     WHERE (amount1_adjusted > 0 OR amount0_adjusted > 0) AND platform = 'uniswap-v3' 
 )
 
-SELECT *
+SELECT 
+  block_timestamp,pool_address,
+  pool_name,
+  token_address,
+  tx_id,
+  amount_in,amount_out,
+  from_address,
+  to_address,
+  CASE WHEN ((amount_usd - other_amount_usd) / amount_usd) > .15 THEN other_amount_usd
+  ELSE amount_usd END AS amount_usd,
+  platform,
+  event_index,
+  direction
 FROM usd_swaps
 
 UNION


### PR DESCRIPTION
Very rare issue but also noticeable. When a tokens price drops fast enough, a ton of tokens will get swapped -- and the price doesn't adjust fast enough. This leads to absurdly high volumes even though decimals and price data are correct. The price is only off on one side of the swap though, when you swap 'Tanking Trash Token' for ETH the ETH price remains good

So what this should do is default to the US dollar amounts for the other token in the swap if one of the token $ amounts gets really high by comparison. Specifically if you swap Token A for Token B and the Token A amount is valued at $100,000 USD but Token B is just $500 it'll default to $500 USD amounts for both (even more specifically if one token swap is worth 15% more than the other, this triggers)

**Testing my side it seems to take really long to run, but DBT as a whole seems slow my side. Whoever's reviewing definitely would appreciate a little sanity check to see if that same issue pops up your side. The logic looks good but I can try and make it more efficient if its running slow.**
