### PR TITLE
Aave hotfixes

### DIFF
--- a/models/ethereum/aave/aave__borrows.sql
+++ b/models/ethereum/aave/aave__borrows.sql
@@ -192,7 +192,7 @@ SELECT
     LOWER(borrow.aave_market) AS aave_market,
     LOWER(underlying.aave_token) AS aave_token,
     borrow.borrow_quantity /
-        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS borrowed_atokens,
+        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS borrowed_tokens,
     borrow.borrow_quantity * COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) /
         POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS borrowed_usd,
     LOWER(borrow.borrower_address) AS borrower_address,

--- a/models/ethereum/aave/aave__borrows.sql
+++ b/models/ethereum/aave/aave__borrows.sql
@@ -200,7 +200,8 @@ SELECT
     LOWER(borrow.lending_pool_contract) AS lending_pool_contract,
     borrow.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    'ethereum' AS blockchain
 FROM
     borrow
     LEFT JOIN coalesced_prices

--- a/models/ethereum/aave/aave__deposits.sql
+++ b/models/ethereum/aave/aave__deposits.sql
@@ -191,7 +191,7 @@ SELECT
     LOWER(deposits.aave_market) AS aave_market,
     LOWER(underlying.aave_token) AS aave_token,
     deposits.deposit_quantity /
-        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS issued_atokens,
+        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS issued_tokens,
     deposits.deposit_quantity * COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) /
         POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS supplied_usd,
     LOWER(deposits.depositor_address) AS depositor_address,

--- a/models/ethereum/aave/aave__deposits.sql
+++ b/models/ethereum/aave/aave__deposits.sql
@@ -198,7 +198,8 @@ SELECT
     LOWER(deposits.lending_pool_contract) AS lending_pool_contract,
     deposits.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    'ethereum' AS blockchain
 FROM
     deposits
     LEFT JOIN coalesced_prices

--- a/models/ethereum/aave/aave__flashloans.sql
+++ b/models/ethereum/aave/aave__flashloans.sql
@@ -157,9 +157,9 @@ flashloan AS(
         block_timestamp,
         event_index,
         CASE
-            WHEN COALESCE(event_inputs:reserve::string,event_inputs:_reserve::string) = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+            WHEN COALESCE(event_inputs:asset::string,event_inputs:_reserve::string) = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
                 THEN '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-                ELSE COALESCE(event_inputs:reserve::string,event_inputs:_reserve::string)
+                ELSE COALESCE(event_inputs:asset::string,event_inputs:_reserve::string)
               END AS aave_market,
         COALESCE(event_inputs:amount,event_inputs:_amount) AS flashloan_quantity, --not adjusted for decimals
         COALESCE(event_inputs:initiator::string,tx_from_address) AS initiator_address,

--- a/models/ethereum/aave/aave__flashloans.sql
+++ b/models/ethereum/aave/aave__flashloans.sql
@@ -205,7 +205,8 @@ SELECT
     LOWER(target_address) AS target_address,
     flashloan.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    'ethereum' AS blockchain
 FROM
     flashloan
     LEFT JOIN coalesced_prices

--- a/models/ethereum/aave/aave__liquidations.sql
+++ b/models/ethereum/aave/aave__liquidations.sql
@@ -213,7 +213,8 @@ SELECT
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS collateral_token_price,
     COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS collateral_token_symbol,
     COALESCE(coalesced_prices_debt.coalesced_price,backup_prices_debt.price,prices_daily_backup_debt.avg_daily_price) AS debt_token_price,
-    COALESCE(coalesced_prices_debt.symbol,backup_prices_debt.symbol,prices_daily_backup_debt.symbol) AS debt_token_symbol
+    COALESCE(coalesced_prices_debt.symbol,backup_prices_debt.symbol,prices_daily_backup_debt.symbol) AS debt_token_symbol,
+    'ethereum' AS blockchain
 FROM
     liquidation
     LEFT JOIN coalesced_prices

--- a/models/ethereum/aave/aave__market_stats.sql
+++ b/models/ethereum/aave/aave__market_stats.sql
@@ -249,13 +249,13 @@ aave_data AS (
 --finally format to spec/with some adjustments
 SELECT
     a.blockhour as block_hour,
+    a.reserve_token AS aave_market,
     a.lending_pool_add, -- use these two for debugging reads, input the underlying token
     a.data_provider, --
     a.reserve_name,
     a.atoken_address,
     a.stable_debt_token_address,
     a.variable_debt_token_address,
-    a.reserve_token AS underlying_contract,
     a.reserve_price,
     atok.price AS atoken_price,
     a.total_liquidity_token,

--- a/models/ethereum/aave/aave__market_stats.sql
+++ b/models/ethereum/aave/aave__market_stats.sql
@@ -206,10 +206,28 @@ aave_prices AS (
        AND p.hour::date >= '2021-05-01'
        AND p.token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
     
-), 
+), deduped_cmc_prices AS (
+    SELECT
+        token_address,
+        hour,
+        decimals,
+        CASE 
+            WHEN symbol = 'KNCL' THEN 'KNC' 
+            WHEN symbol = 'AENJ' THEN 'aENJ' 
+            WHEN symbol = 'AETH' THEN 'aETH'
+        ELSE symbol 
+        END AS symbol,
+        AVG(price) AS price -- table has duplicated rows for KNC / KNCL so we need to do a trick
+    FROM
+        {{ref('ethereum__token_prices_hourly')}}
+    WHERE 1=1
+        AND hour::date >= '2021-01-01'
+    GROUP BY 1,2,3,4
+),
 -- calculate what we can
 aave_data AS (
   SELECT 
+    DISTINCT
           a.blockhour,
           a.reserve_token,
           --l.address_name AS reserve_name,
@@ -241,41 +259,42 @@ aave_data AS (
   LEFT OUTER JOIN
   aave_prices ap ON a.reserve_token = ap.token_address AND a.blockhour = ap.hour
   LEFT OUTER JOIN
-  {{ref('ethereum__token_prices_hourly')}} p ON a.reserve_token = p.token_address AND a.blockhour = p.hour
+  deduped_cmc_prices p ON a.reserve_token = p.token_address AND a.blockhour = p.hour
   ORDER BY reserve_token, blockhour DESC
   
 )
 
 --finally format to spec/with some adjustments
 SELECT
-    a.blockhour as block_hour,
-    a.reserve_token AS aave_market,
-    a.lending_pool_add, -- use these two for debugging reads, input the underlying token
-    a.data_provider, --
-    a.reserve_name,
-    a.atoken_address,
-    a.stable_debt_token_address,
-    a.variable_debt_token_address,
-    a.reserve_price,
-    atok.price AS atoken_price,
-    a.total_liquidity_token,
-    a.total_liquidity_usd,
-    a.total_stable_debt_token,
-    a.total_stable_debt_usd,
-    a.total_variable_debt_token,
-    a.total_variable_debt_usd,
-    a.liquidity_rate AS supply_rate,
-    a.stbl_borrow_rate AS borrow_rate_stable,
-    a.variable_borrow_rate AS borrow_rate_variable,
-    aave.price AS aave_price,
-    a.aave_version,
-    'ethereum' AS blockchain
+    DISTINCT
+        a.blockhour as block_hour,
+        a.reserve_token AS aave_market,
+        a.lending_pool_add, -- use these two for debugging reads, input the underlying token
+        a.data_provider, --
+        a.reserve_name,
+        a.atoken_address,
+        a.stable_debt_token_address,
+        a.variable_debt_token_address,
+        a.reserve_price,
+        atok.price AS atoken_price,
+        a.total_liquidity_token,
+        a.total_liquidity_usd,
+        a.total_stable_debt_token,
+        a.total_stable_debt_usd,
+        a.total_variable_debt_token,
+        a.total_variable_debt_usd,
+        a.liquidity_rate AS supply_rate,
+        a.stbl_borrow_rate AS borrow_rate_stable,
+        a.variable_borrow_rate AS borrow_rate_variable,
+        aave.price AS aave_price,
+        a.aave_version,
+        'ethereum' AS blockchain
 FROM 
 aave_data a
 LEFT OUTER JOIN
-{{ref('ethereum__token_prices_hourly')}} atok
+deduped_cmc_prices atok
 ON a.atoken_address = atok.token_address AND a.blockhour = atok.hour
 LEFT OUTER JOIN
-{{ref('ethereum__token_prices_hourly')}} aave
+deduped_cmc_prices aave
 ON aave.token_address = LOWER('0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9') AND a.blockhour = aave.hour
-ORDER BY underlying_contract, blockhour DESC
+ORDER BY aave_market, blockhour DESC

--- a/models/ethereum/aave/aave__repayments.sql
+++ b/models/ethereum/aave/aave__repayments.sql
@@ -192,7 +192,7 @@ SELECT
     LOWER(repay.aave_market) AS aave_market,
     LOWER(underlying.aave_token) AS aave_token,
     repay.repayed_amount /
-        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS repayed_atokens,
+        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS repayed_tokens,
     repay.repayed_amount * COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) /
         POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS repayed_amount_usd,
     repay.repayer_address AS payer,

--- a/models/ethereum/aave/aave__repayments.sql
+++ b/models/ethereum/aave/aave__repayments.sql
@@ -200,7 +200,8 @@ SELECT
     LOWER(repay.lending_pool_contract) AS lending_pool_contract,
     repay.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    'ethereum' AS blockchain
 FROM
     repay
     LEFT JOIN coalesced_prices

--- a/models/ethereum/aave/aave__repayments.sql
+++ b/models/ethereum/aave/aave__repayments.sql
@@ -157,9 +157,9 @@ repay AS(
         block_timestamp,
         event_index,
         CASE
-            WHEN COALESCE(event_inputs:reserve::string,event_inputs:_reserve::string) = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+            WHEN COALESCE(event_inputs:vault::string,event_inputs:_reserve::string) = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
                 THEN '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-                ELSE COALESCE(event_inputs:reserve::string,event_inputs:_reserve::string)
+                ELSE COALESCE(event_inputs:vault::string,event_inputs:_reserve::string)
               END AS aave_market,
         COALESCE(event_inputs:amount,event_inputs:_amountMinusFees) AS repayed_amount, --not adjusted for decimals
         tx_from_address AS repayer_address,

--- a/models/ethereum/aave/aave__withdraws.sql
+++ b/models/ethereum/aave/aave__withdraws.sql
@@ -197,7 +197,8 @@ SELECT
     LOWER(withdraw.depositor) AS depositor_address,
     withdraw.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    'ethereum' AS blockchain
 FROM
     withdraw
     LEFT JOIN coalesced_prices

--- a/models/ethereum/aave/aave__withdraws.sql
+++ b/models/ethereum/aave/aave__withdraws.sql
@@ -191,7 +191,7 @@ SELECT
     LOWER(withdraw.aave_market) AS aave_market,
     LOWER(underlying.aave_token) AS aave_token,
     withdraw.withdraw_amount /
-        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS withdrawn_atokens,
+        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS withdrawn_tokens,
     withdraw.withdraw_amount * COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) /
         POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS withdrawn_usd,
     LOWER(withdraw.depositor) AS depositor_address,


### PR DESCRIPTION
-- Fixes
--- events parsing in repayments/flashloans
Fixes two issues causing nulls (V2/AMM exclusively) in `aave.repayments` and `aave.flashloans`. The event inputs wasn't parsing to something that was an exact match for etherscan, so the reserve token was getting grabbed incorrectly (which disrupted everything else). 

* `aave.repayments`: event_inputs:reserve -> event_inputs:vault
* `aave.flashloans`: event_inputs:reserve    -> event_inputs:asset

Small changes but just about everything was nulling for these two tables (unless V1)

--- `market_stats`
Removed some dups by carrying over some code from MisterY's tables. A few aTokens had multiple symbols (aETH had AETH and aETH, AENJ had aENJ and AENJ). Fixed a number of nuls into the bargain

--- Name changes

- No longer using atoken amounts -> renamed to token amounts. These are all really in terms of the underlying asset (i.e. USDC not aUSDC) so it really doesn't make any sense to call them otherwise, and is misleading.

- `market_stats.underlying_contract` -> `market_stats.aave_market`: reserves/underlying contracts/markets get referred to as `aave_market` everywhere else so switched for consistency. Also slightly adjusted the column ordering for much the same reason, to bring it more to the front

--- Misc
- Added a column for `blockchain` (always Ethereum for now) to tables that hadn't had it (it had been asked for during the design phase so there wasn't any confusion with Polygon)