### PR TITLE
Aave hotfixes #2

### DIFF
--- a/models/ethereum/aave/aave__borrows.sql
+++ b/models/ethereum/aave/aave__borrows.sql
@@ -200,7 +200,7 @@ SELECT
     LOWER(borrow.lending_pool_contract) AS lending_pool_contract,
     borrow.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol,REGEXP_REPLACE(l.address_name,'AAVE.*: a','')) AS symbol,
     'ethereum' AS blockchain
 FROM
     borrow
@@ -219,3 +219,5 @@ FROM
         AND borrow.aave_version = underlying.aave_version
     LEFT JOIN decimals_backup
         ON LOWER(borrow.aave_market) = LOWER(decimals_backup.token_address)
+    LEFT OUTER JOIN
+    {{source('ethereum', 'ethereum_address_labels')}} l ON LOWER(underlying.aave_token) = l.address

--- a/models/ethereum/aave/aave__deposits.sql
+++ b/models/ethereum/aave/aave__deposits.sql
@@ -209,7 +209,7 @@ SELECT
     LOWER(deposits.lending_pool_contract) AS lending_pool_contract,
     deposits.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol,REGEXP_REPLACE(l.address_name,'AAVE.*: a','')) AS symbol,
     'ethereum' AS blockchain
 FROM
     deposits
@@ -228,3 +228,5 @@ FROM
         AND deposits.aave_version = underlying.aave_version
     LEFT JOIN decimals_backup
         ON LOWER(deposits.aave_market) = LOWER(decimals_backup.token_address)
+    LEFT OUTER JOIN
+    {{source('ethereum', 'ethereum_address_labels')}} l ON LOWER(underlying.aave_token) = l.address

--- a/models/ethereum/aave/aave__deposits.sql
+++ b/models/ethereum/aave/aave__deposits.sql
@@ -83,20 +83,31 @@ backup_prices AS(
         AND hour::date >= '2021-01-01'
     GROUP BY 1,2,3,4
 ),
-
+-- decimals backup
+decimals_backup AS(
+    SELECT
+        address AS token_address,
+        meta:decimals AS decimals,
+        name
+    FROM
+        {{source('ethereum', 'ethereum_contracts')}}
+    WHERE 1=1
+        AND meta:decimals IS NOT NULL
+),
 
 prices_hourly AS(
     SELECT
         underlying.aave_token,
-        underlying.token_contract,
+        LOWER(underlying.token_contract) as token_contract,
         underlying.aave_version,
-        (oracle.value_ethereum / POW(10,(18 - backup_prices.decimals))) * eth_prices.price AS oracle_price,
+        (oracle.value_ethereum / POW(10,(18 - dc.decimals))) * eth_prices.price AS oracle_price,
         backup_prices.price AS backup_price,
         oracle.block_hour AS oracle_hour,
         backup_prices.hour AS backup_prices_hour,
         eth_prices.price AS eth_price,
-        backup_prices.decimals AS decimals,
-        backup_prices.symbol
+        dc.decimals AS decimals,
+        backup_prices.symbol,
+        value_ethereum
     FROM
         underlying
         LEFT JOIN oracle
@@ -105,9 +116,9 @@ prices_hourly AS(
             ON LOWER(underlying.token_contract) = LOWER(backup_prices.token_address)
             AND oracle.block_hour = backup_prices.hour
         LEFT JOIN {{ref('ethereum__token_prices_hourly')}} eth_prices
-            ON oracle.block_hour = eth_prices.hour
-            AND eth_prices.hour::date >= '2021-01-01'
-            AND eth_prices.symbol = 'ETH'
+            ON oracle.block_hour = eth_prices.hour AND eth_prices.token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        LEFT JOIN decimals_backup dc
+            ON oracle.token_address = dc.token_address
 ),
 
 

--- a/models/ethereum/aave/aave__flashloans.sql
+++ b/models/ethereum/aave/aave__flashloans.sql
@@ -84,19 +84,31 @@ backup_prices AS(
     GROUP BY 1,2,3,4
 ),
 
+-- decimals backup
+decimals_backup AS(
+    SELECT
+        address AS token_address,
+        meta:decimals AS decimals,
+        name
+    FROM
+        {{source('ethereum', 'ethereum_contracts')}}
+    WHERE 1=1
+        AND meta:decimals IS NOT NULL
+),
 
 prices_hourly AS(
     SELECT
         underlying.aave_token,
-        underlying.token_contract,
+        LOWER(underlying.token_contract) as token_contract,
         underlying.aave_version,
-        (oracle.value_ethereum / POW(10,(18 - backup_prices.decimals))) * eth_prices.price AS oracle_price,
+        (oracle.value_ethereum / POW(10,(18 - dc.decimals))) * eth_prices.price AS oracle_price,
         backup_prices.price AS backup_price,
         oracle.block_hour AS oracle_hour,
         backup_prices.hour AS backup_prices_hour,
         eth_prices.price AS eth_price,
-        backup_prices.decimals AS decimals,
-        backup_prices.symbol
+        dc.decimals AS decimals,
+        backup_prices.symbol,
+        value_ethereum
     FROM
         underlying
         LEFT JOIN oracle
@@ -105,9 +117,9 @@ prices_hourly AS(
             ON LOWER(underlying.token_contract) = LOWER(backup_prices.token_address)
             AND oracle.block_hour = backup_prices.hour
         LEFT JOIN {{ref('ethereum__token_prices_hourly')}} eth_prices
-            ON oracle.block_hour = eth_prices.hour
-            AND eth_prices.hour::date >= '2021-01-01'
-            AND eth_prices.symbol = 'ETH'
+            ON oracle.block_hour = eth_prices.hour AND eth_prices.token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        LEFT JOIN decimals_backup dc
+            ON oracle.token_address = dc.token_address
 ),
 
 
@@ -138,17 +150,6 @@ prices_daily_backup AS(
     GROUP BY 1,2,3
 ),
 
--- decimals backup
-decimals_backup AS(
-    SELECT
-        address AS token_address,
-        meta:decimals AS decimals,
-        name
-    FROM
-        {{source('ethereum', 'ethereum_contracts')}}
-    WHERE 1=1
-        AND meta:decimals IS NOT NULL
-),
 
 --deposits into Aave LendingPool contract
 flashloan AS(

--- a/models/ethereum/aave/aave__flashloans.sql
+++ b/models/ethereum/aave/aave__flashloans.sql
@@ -206,7 +206,7 @@ SELECT
     LOWER(target_address) AS target_address,
     flashloan.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol,REGEXP_REPLACE(l.address_name,'AAVE.*: a','')) AS symbol,
     'ethereum' AS blockchain
 FROM
     flashloan
@@ -225,3 +225,5 @@ FROM
         AND flashloan.aave_version = underlying.aave_version
     LEFT JOIN decimals_backup
         ON LOWER(flashloan.aave_market) = LOWER(decimals_backup.token_address)
+    LEFT OUTER JOIN
+    {{source('ethereum', 'ethereum_address_labels')}} l ON LOWER(underlying.aave_token) = l.address

--- a/models/ethereum/aave/aave__liquidations.sql
+++ b/models/ethereum/aave/aave__liquidations.sql
@@ -214,7 +214,7 @@ SELECT
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS collateral_token_price,
     COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS collateral_token_symbol,
     COALESCE(coalesced_prices_debt.coalesced_price,backup_prices_debt.price,prices_daily_backup_debt.avg_daily_price) AS debt_token_price,
-    COALESCE(coalesced_prices_debt.symbol,backup_prices_debt.symbol,prices_daily_backup_debt.symbol) AS debt_token_symbol,
+    COALESCE(coalesced_prices_debt.symbol,backup_prices_debt.symbol,prices_daily_backup_debt.symbol,REGEXP_REPLACE(l.address_name,'AAVE.*: a','')) AS debt_token_symbol,
     'ethereum' AS blockchain
 FROM
     liquidation
@@ -249,3 +249,5 @@ FROM
         AND liquidation.aave_version = underlying_debt.aave_version
     LEFT JOIN decimals_backup AS decimals_backup_debt
         ON LOWER(liquidation.debt_asset) = LOWER(decimals_backup_debt.token_address)
+    LEFT OUTER JOIN
+    {{source('ethereum', 'ethereum_address_labels')}} l ON LOWER(underlying.aave_token) = l.address

--- a/models/ethereum/aave/aave__liquidations.sql
+++ b/models/ethereum/aave/aave__liquidations.sql
@@ -83,20 +83,31 @@ backup_prices AS(
         AND hour::date >= '2021-01-01'
     GROUP BY 1,2,3,4
 ),
-
+-- decimals backup
+decimals_backup AS(
+    SELECT
+        address AS token_address,
+        meta:decimals AS decimals,
+        name
+    FROM
+        {{source('ethereum', 'ethereum_contracts')}}
+    WHERE 1=1
+        AND meta:decimals IS NOT NULL
+),
 
 prices_hourly AS(
     SELECT
         underlying.aave_token,
-        underlying.token_contract,
+        LOWER(underlying.token_contract) as token_contract,
         underlying.aave_version,
-        (oracle.value_ethereum / POW(10,(18 - backup_prices.decimals))) * eth_prices.price AS oracle_price,
+        (oracle.value_ethereum / POW(10,(18 - dc.decimals))) * eth_prices.price AS oracle_price,
         backup_prices.price AS backup_price,
         oracle.block_hour AS oracle_hour,
         backup_prices.hour AS backup_prices_hour,
         eth_prices.price AS eth_price,
-        backup_prices.decimals AS decimals,
-        backup_prices.symbol
+        dc.decimals AS decimals,
+        backup_prices.symbol,
+        value_ethereum
     FROM
         underlying
         LEFT JOIN oracle
@@ -105,9 +116,9 @@ prices_hourly AS(
             ON LOWER(underlying.token_contract) = LOWER(backup_prices.token_address)
             AND oracle.block_hour = backup_prices.hour
         LEFT JOIN {{ref('ethereum__token_prices_hourly')}} eth_prices
-            ON oracle.block_hour = eth_prices.hour
-            AND eth_prices.hour::date >= '2021-01-01'
-            AND eth_prices.symbol = 'ETH'
+            ON oracle.block_hour = eth_prices.hour AND eth_prices.token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        LEFT JOIN decimals_backup dc
+            ON oracle.token_address = dc.token_address
 ),
 
 
@@ -138,17 +149,7 @@ prices_daily_backup AS(
     GROUP BY 1,2,3
 ),
 
--- decimals backup
-decimals_backup AS(
-    SELECT
-        address AS token_address,
-        meta:decimals AS decimals,
-        name
-    FROM
-        {{source('ethereum', 'ethereum_contracts')}}
-    WHERE 1=1
-        AND meta:decimals IS NOT NULL
-),
+
 
 --liquidations to Aave LendingPool contract
 liquidation AS(--need to fix aave v1

--- a/models/ethereum/aave/aave__market_stats.sql
+++ b/models/ethereum/aave/aave__market_stats.sql
@@ -195,9 +195,10 @@ oracle AS(
 ),
 --pull hourly prices for each underlying
 aave_prices AS (
+
     SELECT
         o.hour,
-        (o.value_ethereum * POWER(10,18)) * p.price AS price, -- this is all to get price in wei to price in USD
+        (o.value_ethereum / POW(10,(18 - dc.decimals))) * p.price AS price, -- this is all to get price in wei to price in USD
         o.token_address
     FROM
     oracle o
@@ -205,6 +206,8 @@ aave_prices AS (
       ON o.hour = p.hour
        AND p.hour::date >= '2021-05-01'
        AND p.token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+  LEFT JOIN decimals_raw dc 
+      ON o.token_address = dc.token_address
     
 ), deduped_cmc_prices AS (
     SELECT

--- a/models/ethereum/aave/aave__repayments.sql
+++ b/models/ethereum/aave/aave__repayments.sql
@@ -83,20 +83,31 @@ backup_prices AS(
         AND hour::date >= '2021-01-01'
     GROUP BY 1,2,3,4
 ),
-
+-- decimals backup
+decimals_backup AS(
+    SELECT
+        address AS token_address,
+        meta:decimals AS decimals,
+        name
+    FROM
+        {{source('ethereum', 'ethereum_contracts')}}
+    WHERE 1=1
+        AND meta:decimals IS NOT NULL
+),
 
 prices_hourly AS(
     SELECT
         underlying.aave_token,
-        underlying.token_contract,
+        LOWER(underlying.token_contract) as token_contract,
         underlying.aave_version,
-        (oracle.value_ethereum / POW(10,(18 - backup_prices.decimals))) * eth_prices.price AS oracle_price,
+        (oracle.value_ethereum / POW(10,(18 - dc.decimals))) * eth_prices.price AS oracle_price,
         backup_prices.price AS backup_price,
         oracle.block_hour AS oracle_hour,
         backup_prices.hour AS backup_prices_hour,
         eth_prices.price AS eth_price,
-        backup_prices.decimals AS decimals,
-        backup_prices.symbol
+        dc.decimals AS decimals,
+        backup_prices.symbol,
+        value_ethereum
     FROM
         underlying
         LEFT JOIN oracle
@@ -105,9 +116,9 @@ prices_hourly AS(
             ON LOWER(underlying.token_contract) = LOWER(backup_prices.token_address)
             AND oracle.block_hour = backup_prices.hour
         LEFT JOIN {{ref('ethereum__token_prices_hourly')}} eth_prices
-            ON oracle.block_hour = eth_prices.hour
-            AND eth_prices.hour::date >= '2021-01-01'
-            AND eth_prices.symbol = 'ETH'
+            ON oracle.block_hour = eth_prices.hour AND eth_prices.token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        LEFT JOIN decimals_backup dc
+            ON oracle.token_address = dc.token_address
 ),
 
 
@@ -138,17 +149,7 @@ prices_daily_backup AS(
     GROUP BY 1,2,3
 ),
 
--- decimals backup
-decimals_backup AS(
-    SELECT
-        address AS token_address,
-        meta:decimals AS decimals,
-        name
-    FROM
-        {{source('ethereum', 'ethereum_contracts')}}
-    WHERE 1=1
-        AND meta:decimals IS NOT NULL
-),
+
 
 --repayments to Aave LendingPool contract
 repay AS(

--- a/models/ethereum/aave/aave__repayments.sql
+++ b/models/ethereum/aave/aave__repayments.sql
@@ -201,7 +201,7 @@ SELECT
     LOWER(repay.lending_pool_contract) AS lending_pool_contract,
     repay.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol,REGEXP_REPLACE(l.address_name,'AAVE.*: a','')) AS symbol,
     'ethereum' AS blockchain
 FROM
     repay
@@ -220,3 +220,5 @@ FROM
         AND repay.aave_version = underlying.aave_version
     LEFT JOIN decimals_backup
         ON LOWER(repay.aave_market) = LOWER(decimals_backup.token_address)
+    LEFT OUTER JOIN
+    {{source('ethereum', 'ethereum_address_labels')}} l ON LOWER(underlying.aave_token) = l.address

--- a/models/ethereum/aave/aave__repayments.sql
+++ b/models/ethereum/aave/aave__repayments.sql
@@ -194,7 +194,7 @@ SELECT
     repay.repayed_amount /
         POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS repayed_tokens,
     repay.repayed_amount * COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) /
-        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS repayed_amount_usd,
+        POW(10,COALESCE(coalesced_prices.decimals,backup_prices.decimals,prices_daily_backup.decimals,decimals_backup.decimals,18)) AS repayed_usd,
     repay.repayer_address AS payer,
     repay.borrower_address AS borrower,
     LOWER(repay.lending_pool_contract) AS lending_pool_contract,

--- a/models/ethereum/aave/aave__withdraws.sql
+++ b/models/ethereum/aave/aave__withdraws.sql
@@ -198,7 +198,7 @@ SELECT
     LOWER(withdraw.depositor) AS depositor_address,
     withdraw.aave_version,
     COALESCE(coalesced_prices.coalesced_price,backup_prices.price,prices_daily_backup.avg_daily_price) AS token_price,
-    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol) AS symbol,
+    COALESCE(coalesced_prices.symbol,backup_prices.symbol,prices_daily_backup.symbol,REGEXP_REPLACE(l.address_name,'AAVE.*: a','')) AS symbol,
     'ethereum' AS blockchain
 FROM
     withdraw
@@ -217,3 +217,5 @@ FROM
         AND withdraw.aave_version = underlying.aave_version
     LEFT JOIN decimals_backup
         ON LOWER(withdraw.aave_market) = LOWER(decimals_backup.token_address)
+    LEFT OUTER JOIN
+    {{source('ethereum', 'ethereum_address_labels')}} l ON LOWER(underlying.aave_token) = l.address

--- a/models/ethereum/aave/aave__withdraws.sql
+++ b/models/ethereum/aave/aave__withdraws.sql
@@ -83,20 +83,31 @@ backup_prices AS(
         AND hour::date >= '2021-01-01'
     GROUP BY 1,2,3,4
 ),
-
+-- decimals backup
+decimals_backup AS(
+    SELECT
+        address AS token_address,
+        meta:decimals AS decimals,
+        name
+    FROM
+        {{source('ethereum', 'ethereum_contracts')}}
+    WHERE 1=1
+        AND meta:decimals IS NOT NULL
+),
 
 prices_hourly AS(
     SELECT
         underlying.aave_token,
-        underlying.token_contract,
+        LOWER(underlying.token_contract) as token_contract,
         underlying.aave_version,
-        (oracle.value_ethereum / POW(10,(18 - backup_prices.decimals))) * eth_prices.price AS oracle_price,
+        (oracle.value_ethereum / POW(10,(18 - dc.decimals))) * eth_prices.price AS oracle_price,
         backup_prices.price AS backup_price,
         oracle.block_hour AS oracle_hour,
         backup_prices.hour AS backup_prices_hour,
         eth_prices.price AS eth_price,
-        backup_prices.decimals AS decimals,
-        backup_prices.symbol
+        dc.decimals AS decimals,
+        backup_prices.symbol,
+        value_ethereum
     FROM
         underlying
         LEFT JOIN oracle
@@ -105,9 +116,9 @@ prices_hourly AS(
             ON LOWER(underlying.token_contract) = LOWER(backup_prices.token_address)
             AND oracle.block_hour = backup_prices.hour
         LEFT JOIN {{ref('ethereum__token_prices_hourly')}} eth_prices
-            ON oracle.block_hour = eth_prices.hour
-            AND eth_prices.hour::date >= '2021-01-01'
-            AND eth_prices.symbol = 'ETH'
+            ON oracle.block_hour = eth_prices.hour AND eth_prices.token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        LEFT JOIN decimals_backup dc
+            ON oracle.token_address = dc.token_address
 ),
 
 
@@ -138,17 +149,7 @@ prices_daily_backup AS(
     GROUP BY 1,2,3
 ),
 
--- decimals backup
-decimals_backup AS(
-    SELECT
-        address AS token_address,
-        meta:decimals AS decimals,
-        name
-    FROM
-        {{source('ethereum', 'ethereum_contracts')}}
-    WHERE 1=1
-        AND meta:decimals IS NOT NULL
-),
+
 
 --withdraws to Aave LendingPool contract
 withdraw AS(--does not retrieve Aave V1


### PR DESCRIPTION
fixes
-- symbols: using ethereum_address_labels as a fallback to make sure we get a symbol even for tokens (like pool tokens) that otherwise don't have them
-- Aave Price Oracle: Using a more consistent source of decimals per contract than what was being used to calculate Oracle prices. Should remove a lot of nulls

name changes
-- changed the repayments amount usd column to just be 'repayments usd' to make naming more consistent