### PR TITLE
Aave hotfix 3

### DIFF
--- a/models/ethereum/aave/aave__market_stats.sql
+++ b/models/ethereum/aave/aave__market_stats.sql
@@ -96,11 +96,11 @@ reads_parsed AS (
 ),
 -- splitting these up for organization
 lending_pools_v2 AS (
-    SELECT * FROM reads_parsed WHERE lending_pool_type = 'LendingPool' AND aave_version <> 'V1'
+    SELECT * FROM reads_parsed WHERE lending_pool_type = 'LendingPool' AND aave_version <> 'Aave V1'
 ), data_providers_v2 AS (
-    SELECT * FROM reads_parsed WHERE lending_pool_type = 'DataProvider' AND aave_version <> 'V1'
+    SELECT * FROM reads_parsed WHERE lending_pool_type = 'DataProvider' AND aave_version <> 'Aave V1'
 ), lending_pools_v1 AS (
-  SELECT * FROM reads_parsed WHERE lending_pool_type = 'LendingPool' AND aave_version = 'V1'
+  SELECT * FROM reads_parsed WHERE lending_pool_type = 'LendingPool' AND aave_version = 'Aave V1'
 ), 
 -- format v2/amm data. Need to combine reads from the lending pool and data provider
 aave_v2 AS (

--- a/models/ethereum/aave/aave__market_stats.sql
+++ b/models/ethereum/aave/aave__market_stats.sql
@@ -194,7 +194,13 @@ oracle AS(
         {{ref('ethereum__reads')}}
     WHERE 
         contract_address = '0xa50ba011c48153de246e5192c8f9258a2ba79ca9' -- check if there is only one oracle
-        AND block_timestamp::date >= '2021-05-01'
+        {% if is_incremental() %}
+        AND block_timestamp::date >= CURRENT_DATE - 2
+        {% else %}
+        AND block_timestamp::date >= CURRENT_DATE - 720
+        {% endif %}
+    
+        
   GROUP BY 1,2
 ),
 --pull hourly prices for each underlying
@@ -208,7 +214,12 @@ aave_prices AS (
     oracle o
     INNER JOIN {{ref('ethereum__token_prices_hourly')}} p
       ON o.hour = p.hour
-       AND p.hour::date >= '2021-05-01'
+        {% if is_incremental() %}
+        AND block_timestamp::date >= CURRENT_DATE - 2
+        {% else %}
+        AND block_timestamp::date >= CURRENT_DATE - 720
+        {% endif %}
+    
        AND p.token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
   LEFT JOIN decimals_raw dc 
       ON o.token_address = dc.token_address

--- a/models/ethereum/aave/aave__market_stats.sql
+++ b/models/ethereum/aave/aave__market_stats.sql
@@ -309,6 +309,7 @@ SELECT
         a.stbl_borrow_rate AS borrow_rate_stable,
         a.variable_borrow_rate AS borrow_rate_variable,
         aave.price AS aave_price,
+        a.utilization_rate,
         a.aave_version,
         'ethereum' AS blockchain
 FROM 

--- a/models/ethereum/aave/aave__market_stats.sql
+++ b/models/ethereum/aave/aave__market_stats.sql
@@ -304,7 +304,7 @@ aave_data AS (
 SELECT
     DISTINCT
         a.blockhour as block_hour,
-        a.reserve_token AS aave_market,
+        UPPER(a.reserve_token) AS aave_market, --uses labels as a fallback, some of which have mixed case
         a.lending_pool_add, -- use these two for debugging reads, input the underlying token
         a.data_provider, --
         a.reserve_name,

--- a/models/ethereum/aave/aave__market_stats.sql
+++ b/models/ethereum/aave/aave__market_stats.sql
@@ -215,9 +215,9 @@ aave_prices AS (
     INNER JOIN {{ref('ethereum__token_prices_hourly')}} p
       ON o.hour = p.hour
         {% if is_incremental() %}
-        AND block_timestamp::date >= CURRENT_DATE - 2
+        AND o.hour >= CURRENT_DATE - 2
         {% else %}
-        AND block_timestamp::date >= CURRENT_DATE - 720
+        AND o.hour >= CURRENT_DATE - 720
         {% endif %}
     
        AND p.token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
@@ -239,7 +239,11 @@ aave_prices AS (
     FROM
         {{ref('ethereum__token_prices_hourly')}}
     WHERE 1=1
-        AND hour::date >= '2021-01-01'
+        {% if is_incremental() %}
+        AND hour >= CURRENT_DATE - 2
+        {% else %}
+        AND hour >= CURRENT_DATE - 720
+        {% endif %}
     GROUP BY 1,2,3,4
 ),
 -- calculate what we can


### PR DESCRIPTION
Bunch of fixes for market stats, removes a lot of nulls and adds a column

* removed some date cutoff's creating nulls still before 2021 (some price related CTE's still had date cutoffs)
* removed a bug that was causing AAVE V1 prices to get properly parsed
* `utilization rate` should've been showing up as a column, made sure it appeared in the table