### PR TITLE
Add sushi

### DIFF
--- a/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
+++ b/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
@@ -105,15 +105,6 @@ WITH v3_pools AS ( -- uni v3
 
     LEFT JOIN {{source('ethereum', 'ethereum_address_labels')}} bbb 
       ON token1 = bbb.address
-
-    -- WHERE 
-    -- p.event_name    = 'PairCreated'
-    -- {% if is_incremental() %}
-    --  block_timestamp >= getdate() - interval '2 days'
-    -- {% else %}
-    --  AND block_timestamp >= getdate() - interval '12 months'
-    -- {% endif %}
-
 ), sushi_write_in AS (
   -- adding a few major sushi pools that were created before we have eth data (this gives us data on swaps with these pools)
   -- edit now uses a table of sushiswap tables 

--- a/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
+++ b/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
@@ -122,6 +122,7 @@ WITH v3_pools AS ( -- uni v3
       NULL AS creation_tx,
       '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
       pool_name,
+      pool_address,
       token0,
       token1,
       platform

--- a/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
+++ b/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
@@ -162,6 +162,7 @@ stack AS (
      *,
     ARRAY_CONSTRUCT(token0,token1) AS tokens
   FROM stack
+  WHERE pool_address IS NOT NULL AND token0 IS NOT NULL AND token1 IS NOT NULL
 
   UNION
 
@@ -181,4 +182,5 @@ stack AS (
 
 SELECT DISTINCT * FROM 
 curve
+WHERE pool_address IS NOT NULL
 

--- a/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
+++ b/models/ethereum/dex/ethereum__dex_liquidity_pools.sql
@@ -21,7 +21,7 @@ WITH v3_pools AS ( -- uni v3
       {{source('uniswapv3_eth','uniswapv3_pools')}}
       WHERE 
       {% if is_incremental() %}
-        creation_time >= getdate() - interval '2 days'
+        creation_time >= getdate() - interval '7 days'
       {% else %}
         creation_time >= getdate() - interval '12 months'
       {% endif %}
@@ -64,7 +64,7 @@ WITH v3_pools AS ( -- uni v3
 
     WHERE p.event_name    = 'PairCreated'
     {% if is_incremental() %}
-      AND creation_time >= getdate() - interval '2 days'
+      AND creation_time >= getdate() - interval '7 days'
     {% else %}
       AND creation_time >= getdate() - interval '12 months'
     {% endif %}
@@ -116,65 +116,17 @@ WITH v3_pools AS ( -- uni v3
 
 ), sushi_write_in AS (
   -- adding a few major sushi pools that were created before we have eth data (this gives us data on swaps with these pools)
-  SELECT  
-        NULL AS creation_time,
-        NULL AS creation_tx,
-        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
-        'WBTC-ETH SLP' AS pool_name,
-        '0xceff51756c56ceffca006cd410b03ffc46dd3a58' AS pool_address,
-        '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599' AS token0,
-        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token1,
-        'sushiswap' AS platform
-  
-  UNION
-  
-  SELECT  
-        NULL AS creation_time,
-        NULL AS creation_tx,
-        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
-        'SUSHI-ETH SLP' AS pool_name,
-        '0x795065dcc9f64b5614c407a6efdc400da6221fb0' AS pool_address,
-        '0x6b3595068778dd592e39a122f4f5a5cf09c90fe2' AS token0,
-        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token1,
-        'sushiswap' AS platform
-  
-  UNION
-  
-  SELECT  
-        NULL AS creation_time,
-        NULL AS creation_tx,
-        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
-        'USDC-ETH SLP' AS pool_name,
-        '0x397ff1542f962076d0bfe58ea045ffa2d347aca0' AS pool_address,
-        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' AS token0,
-        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token1,
-        'sushiswap' AS platform
-  
-  
-  UNION
-  
-  SELECT  
-        NULL AS creation_time,
-        NULL AS creation_tx,
-        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
-        'ETH-USDT SLP' AS pool_name,
-        '0x06da0fd433c1a5d7a4faa01111c044910a184553' AS pool_address,
-        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token0,
-        '0xdac17f958d2ee523a2206206994597c13d831ec7' AS token1,
-        'sushiswap' AS platform
-    
-  
-  UNION
-  
-  SELECT  
-        NULL AS creation_time,
-        NULL AS creation_tx,
-        '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
-        'DAI-ETH SLP' AS pool_name,
-        '0xc3d03e4f041fd4cd388c549ee2a29a9e5075882f' AS pool_address,
-        '0x6b175474e89094c44da98b954eedeac495271d0f' AS token0,
-        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' AS token1,
-        'sushiswap' AS platform
+  -- edit now uses a table of sushiswap tables 
+  SELECT
+      NULL AS creation_time,
+      NULL AS creation_tx,
+      '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' AS factory_address,
+      pool_name,
+      token0,
+      token1,
+      platform
+
+  FROM flipside_dev_db.dbt.sushi_liquidity_pools
   
 ), new_sushi AS (
   SELECT s.* -- future proofing: once the eth backfill is done these manual write-ins will be dups

--- a/models/ethereum/dex/ethereum__dex_liquidity_pools.yml
+++ b/models/ethereum/dex/ethereum__dex_liquidity_pools.yml
@@ -4,14 +4,16 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - CREATION_TX
+            - POOL_ADDRESS
     columns:
       - name: CREATION_TIME
         tests:
-          - not_null
+          - not_null:
+              where: PLATFORM NOT IN ('uniswap-v2', 'sushiswap', 'curve')
       - name: CREATION_TX
         tests:
-          - not_null
+          - not_null:
+              where: PLATFORM NOT IN ('uniswap-v2', 'sushiswap', 'curve')
       - name: FACTORY_ADDRESS
         tests:
           - not_null
@@ -27,10 +29,13 @@ models:
               regex: 0[xX][0-9a-fA-F]+
       - name: POOL_NAME
         tests:
-          - not_null
+          - not_null:
+              where: PLATFORM <> 'uniswap-v3'
       - name: TOKEN0
         tests:
-          - not_null
+          - not_null:
+              where: PLATFORM <> 'curve'
       - name: TOKEN1
         tests:
-          - not_null
+          - not_null:
+              where: PLATFORM <> 'curve'

--- a/models/ethereum/dex/ethereum__dex_swaps.sql
+++ b/models/ethereum/dex/ethereum__dex_swaps.sql
@@ -41,6 +41,19 @@ WITH decimals_raw as (
   FROM decimals_raw
   QUALIFY (row_number() OVER (partition by token_address order by weight desc)) = 1
 ),
+-- daily avg price used when hourly price is missing (it happens a lot)
+prices_daily_backup AS(
+    SELECT
+        token_address,
+        date_trunc('day',hour) AS block_date,
+        AVG(price) AS price,
+        MAX(decimals) AS decimals
+    FROM
+        {{ref('ethereum__token_prices_hourly')}}
+    WHERE 1=1
+    GROUP BY 1,2
+),
+
  usd_swaps AS (
   SELECT DISTINCT
     block_timestamp, 
@@ -48,12 +61,12 @@ WITH decimals_raw as (
     p.pool_name,
     p.token0 AS token_address,
     tx_id, 
-    event_inputs:amount0In / POWER(10, d0.decimals) AS amount_in,
-    event_inputs:amount0Out / POWER(10, d0.decimals) AS amount_out, 
+    event_inputs:amount0In / POWER(10, COALESCE(d0.decimals,backup0.decimals)) AS amount_in,
+    event_inputs:amount0Out / POWER(10, COALESCE(d0.decimals,backup0.decimals)) AS amount_out, 
     REGEXP_REPLACE(event_inputs:sender,'\"','') AS from_address,
     REGEXP_REPLACE(event_inputs:to,'\"','') AS to_address,
-    CASE WHEN event_inputs:amount0In > 0 THEN event_inputs:amount0In * price0.price / POWER(10, d0.decimals) 
-         ELSE event_inputs:amount0Out * price0.price / POWER(10, d0.decimals) END
+    CASE WHEN event_inputs:amount0In > 0 THEN event_inputs:amount0In * COALESCE(price0.price,backup0.price) / POWER(10, COALESCE(d0.decimals,backup0.decimals)) 
+         ELSE event_inputs:amount0Out * COALESCE(price0.price,backup0.price) / POWER(10, COALESCE(d0.decimals,backup0.decimals)) END
     AS amount_usd,
     --CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
     --     ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
@@ -69,6 +82,9 @@ WITH decimals_raw as (
 
   LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price0 
     ON p.token0 = price0.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
+
+  LEFT JOIN prices_daily_backup backup0
+    ON p.token0 = backup0.token_address AND DATE_TRUNC('day',s0.block_timestamp) = backup0.block_date
 
   LEFT JOIN decimals d0
     ON p.token0 = d0.token_address
@@ -95,12 +111,12 @@ WITH decimals_raw as (
     p.pool_name,
     p.token1 AS token_address,
     tx_id, 
-    event_inputs:amount1In / POWER(10, d1.decimals) AS amount_in,
-    event_inputs:amount1Out / POWER(10, d1.decimals) AS amount_out, 
+    event_inputs:amount1In / POWER(10, COALESCE(d1.decimals,backup1.decimals)) AS amount_in,
+    event_inputs:amount1Out / POWER(10, COALESCE(d1.decimals,backup1.decimals)) AS amount_out, 
     REGEXP_REPLACE(event_inputs:sender,'\"','') AS from_address,
     REGEXP_REPLACE(event_inputs:to,'\"','') AS to_address,
-    CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
-         ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
+    CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * COALESCE(price1.price,backup1.price) / POWER(10, COALESCE(d1.decimals,backup1.decimals))
+         ELSE event_inputs:amount1Out * COALESCE(price1.price,backup1.price) / POWER(10, COALESCE(d1.decimals,backup1.decimals)) END
     AS amount_usd,
     -- CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
     --     ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
@@ -123,6 +139,9 @@ WITH decimals_raw as (
 
   LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price1
     ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price1.hour
+
+  LEFT JOIN prices_daily_backup backup1
+    ON p.token1 = backup1.token_address AND DATE_TRUNC('day',s0.block_timestamp) = backup1.block_date
 
   LEFT JOIN decimals d1
     ON p.token1 = d1.token_address

--- a/models/ethereum/dex/ethereum__dex_swaps.sql
+++ b/models/ethereum/dex/ethereum__dex_swaps.sql
@@ -82,7 +82,7 @@ WITH decimals_raw as (
   WHERE event_name = 'Swap' AND platform <> 'uniswap-v3' 
 
   {% if is_incremental() %}
-    AND block_timestamp >= getdate() - interval '2 days'
+    AND block_timestamp >= getdate() - interval '7 days'
   {% else %}
     AND block_timestamp >= getdate() - interval '9 months'
   {% endif %}
@@ -131,7 +131,7 @@ WITH decimals_raw as (
   WHERE 
       event_name = 'Swap' AND platform <> 'uniswap-v3' 
   {% if is_incremental() %}
-    AND block_timestamp >= getdate() - interval '2 days'
+    AND block_timestamp >= getdate() - interval '7 days'
   {% else %}
     AND block_timestamp >= getdate() - interval '9 months'
   {% endif %}
@@ -232,7 +232,7 @@ WITH decimals_raw as (
   FROM {{ref('ethereum_dbt__curve_swaps')}} c
   WHERE 
     {% if is_incremental() %}
-      block_timestamp >= getdate() - interval '2 days'
+      block_timestamp >= getdate() - interval '7 days'
     {% else %}
       block_timestamp >= getdate() - interval '12 months'
     {% endif %}
@@ -257,7 +257,7 @@ WITH decimals_raw as (
   FROM {{ref('ethereum_dbt__curve_swaps')}} c
   WHERE 
     {% if is_incremental() %}
-      block_timestamp >= getdate() - interval '2 days'
+      block_timestamp >= getdate() - interval '7 days'
     {% else %}
       block_timestamp >= getdate() - interval '12 months'
     {% endif %}

--- a/models/ethereum/dex/ethereum__dex_swaps.sql
+++ b/models/ethereum/dex/ethereum__dex_swaps.sql
@@ -68,9 +68,6 @@ prices_daily_backup AS(
     CASE WHEN event_inputs:amount0In > 0 THEN event_inputs:amount0In * COALESCE(price0.price,backup0.price) / POWER(10, COALESCE(d0.decimals,backup0.decimals)) 
          ELSE event_inputs:amount0Out * COALESCE(price0.price,backup0.price) / POWER(10, COALESCE(d0.decimals,backup0.decimals)) END
     AS amount_usd,
-    --CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
-    --     ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
-    --AS other_amount_usd,
     CASE WHEN p.factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform,
     event_index,
     CASE WHEN event_inputs:amount0In > 0 THEN 'IN' 
@@ -88,12 +85,6 @@ prices_daily_backup AS(
 
   LEFT JOIN decimals d0
     ON p.token0 = d0.token_address
-
-  --LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price1
-  --  ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
-
-  --LEFT JOIN decimals d1
-  --  ON p.token1 = d1.token_address
 
   WHERE event_name = 'Swap' AND platform <> 'uniswap-v3' 
 
@@ -118,9 +109,6 @@ prices_daily_backup AS(
     CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * COALESCE(price1.price,backup1.price) / POWER(10, COALESCE(d1.decimals,backup1.decimals))
          ELSE event_inputs:amount1Out * COALESCE(price1.price,backup1.price) / POWER(10, COALESCE(d1.decimals,backup1.decimals)) END
     AS amount_usd,
-    -- CASE WHEN event_inputs:amount1In > 0 THEN event_inputs:amount1In * price1.price / POWER(10, d1.decimals) 
-    --     ELSE event_inputs:amount1Out * price1.price / POWER(10, d1.decimals) END
-    --AS other_amount_usd,
     CASE WHEN p.factory_address = '0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac' THEN 'sushiswap' ELSE 'uniswap-v2' END AS platform,
     event_index,
     CASE WHEN event_inputs:amount1In > 0 THEN 'IN' 
@@ -130,12 +118,6 @@ prices_daily_backup AS(
 
   LEFT JOIN {{ref('ethereum__dex_liquidity_pools')}} p 
     ON s0.contract_address = p.pool_address
-
-  --LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price0 
-  --  ON p.token0 = price0.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price0.hour
-
-  --LEFT JOIN decimals d0
-  --  ON p.token0 = d0.token_address
 
   LEFT JOIN {{ref('ethereum__token_prices_hourly')}} price1
     ON p.token1 = price1.token_address AND DATE_TRUNC('hour',s0.block_timestamp) = price1.hour
@@ -217,8 +199,6 @@ prices_daily_backup AS(
     amount_in,amount_out,
     from_address,
     to_address,
-    -- CASE WHEN ((amount_usd - other_amount_usd) / amount_usd) > .15 THEN other_amount_usd
-    -- ELSE amount_usd END AS amount_usd,
     amount_usd,
     platform,
     event_index,

--- a/models/ethereum/dex/ethereum__dex_swaps.yml
+++ b/models/ethereum/dex/ethereum__dex_swaps.yml
@@ -4,25 +4,24 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
+            - DIRECTION
+            - EVENT_INDEX
             - TX_ID
     columns:
-      - name: AMOUNT_IN
+      - name: AMOUNT_IN # TODO: proportional null test
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - decimal
                 - float
-      - name: AMOUNT_OUT
+      - name: AMOUNT_OUT # TODO: proportional null test
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - decimal
                 - float
-      - name: AMOUNT_USD
+      - name: AMOUNT_USD # TODO: proportional null test
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_be_in_type_list:
               column_type_list:
                 - decimal
@@ -51,15 +50,16 @@ models:
           - not_null
       - name: POOL_ADDRESS
         tests:
-          - not_null
+          - not_null:
+              where: PLATFORM <> 'uniswap-v3'
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
       - name: POOL_NAME
         tests:
-          - not_null
+          - not_null:
+              where: PLATFORM <> 'uniswap-v3'
       - name: ROUTER
         tests:
-          - not_null
       - name: TOKEN_ADDRESS
         tests:
           - not_null


### PR DESCRIPTION
Adds in sushiswap pools pulled from the Graph (which sushiswaps own analytics page uses behind the scenes. https://analytics.sushi.com/pairs). We can't get swaps that come from pools not in `dex_liquidity_pools`, BUT `dex_liquidity_pools` can't pick up pools we're missing the original creation tx for.

This all boils down to we are missing swaps from any pools created before February (as far as events_emitted data goes back too). This pulls pools from theGraph to augment our own numbers -- we still don't get the creation tx but we get the important info we need to parse swaps (if we do have the creation tx we use our data).

Also this increases the incremental refresh lookback to 7 days from 2 in dex swaps, which will remove some null USD values.