### PR TITLE
SQL Model Update For Terra Columbus-5 Upgrade

### DIFF
--- a/models/terra/terra_dbt__blocks.sql
+++ b/models/terra/terra_dbt__blocks.sql
@@ -1,26 +1,50 @@
-{{ 
-  config(
-    materialized='incremental',
-    unique_key='chain_id || block_id', 
-    incremental_strategy='delete+insert',
-    tags=['snowflake', 'terra_silver', 'terra_blocks']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  unique_key = 'chain_id || block_id',
+  incremental_strategy = 'delete+insert',
+  tags = ['snowflake', 'terra_silver', 'terra_blocks']
+) }}
 
-with base_tables as (
-  select *
-  from {{source('bronze', 'prod_terra_sink_645110886')}}
-  where record_content:model:name::string = 'terra_block_model'
-  {% if is_incremental() %}
-        AND (record_metadata:CreateTime::int/1000)::timestamp::date >= (select dateadd('day',-1,max(system_created_at::date)) from {{source('terra_dbt', 'blocks')}})
-  {% endif %}
-  )
+WITH base_tables AS (
 
-select (record_metadata:CreateTime::int/1000)::timestamp as system_created_at
-, record_content:model:blockchain::string as chain_id
-, t.value:block_id::int as block_id
-, t.value:block_timestamp::timestamp as block_timestamp
-, t.value:blockchain::string as blockchain
-, t.value:proposer_address::string as proposer_address
-from base_tables
-,lateral flatten(input => record_content:results) t
+  SELECT
+    *
+  FROM
+    {{ source(
+      'bronze',
+      'prod_terra_sink_645110886'
+    ) }}
+  WHERE
+    record_content :model :name :: STRING IN (
+      'terra_block_model',
+      'terra-5_block_model'
+    )
+
+{% if is_incremental() %}
+AND (
+  record_metadata :CreateTime :: INT / 1000
+) :: TIMESTAMP :: DATE >= (
+  SELECT
+    DATEADD('day', -1, MAX(system_created_at :: DATE))
+  FROM
+    {{ source(
+      'terra_dbt',
+      'blocks'
+    ) }}
+)
+{% endif %}
+)
+SELECT
+  (
+    record_metadata :CreateTime :: INT / 1000
+  ) :: TIMESTAMP AS system_created_at,
+  record_content :model :blockchain :: STRING AS chain_id,
+  t.value :block_id :: INT AS block_id,
+  t.value :block_timestamp :: TIMESTAMP AS block_timestamp,
+  t.value :blockchain :: STRING AS blockchain,
+  t.value :proposer_address :: STRING AS proposer_address
+FROM
+  base_tables,
+  LATERAL FLATTEN(
+    input => record_content :results
+  ) t

--- a/models/terra/terra_dbt__msg_events.sql
+++ b/models/terra/terra_dbt__msg_events.sql
@@ -1,35 +1,59 @@
-{{ 
-  config(
-    materialized='incremental',
-    unique_key='chain_id || block_id || tx_id || msg_index || event_index', 
-    incremental_strategy='delete+insert',
-    tags=['snowflake', 'terra_silver', 'terra_msg_events']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  unique_key = 'chain_id || block_id || tx_id || msg_index || event_index',
+  incremental_strategy = 'delete+insert',
+  tags = ['snowflake', 'terra_silver', 'terra_msg_events']
+) }}
 
-with base_tables as (
-  select *
-  from {{source('bronze', 'prod_terra_sink_645110886')}}
-  where record_content:model:name::string = 'terra_msg_event_model'
-  {% if is_incremental() %}
-        AND (record_metadata:CreateTime::int/1000)::timestamp::date >= (select dateadd('day',-1,max(system_created_at::date)) from {{source('terra_dbt', 'msg_events')}})
-  {% endif %}
-  )
+WITH base_tables AS (
 
-select (record_metadata:CreateTime::int/1000)::timestamp as system_created_at,
-      t.value:blockchain::string as blockchain,
-      t.value:block_id::bigint as block_id,
-      t.value:block_timestamp::timestamp as block_timestamp,
-      t.value:chain_id::string as chain_id,
-      t.value:tx_id::string as tx_id,
-      t.value:tx_module::string as tx_module,
-      t.value:tx_status::string as tx_status,
-      t.value:tx_type::string as tx_type,
-      t.value:msg_index::integer as msg_index,
-      t.value:msg_type::string as msg_type,
-      t.value:msg_module::string as msg_module,
-      t.value:event_type::string as event_type,
-      t.value:event_index::integer as event_index,
-      t.value:event_attributes::object as event_attributes
-from base_tables
-,lateral flatten(input => record_content:results) t
+  SELECT
+    *
+  FROM
+    {{ source(
+      'bronze',
+      'prod_terra_sink_645110886'
+    ) }}
+  WHERE
+    record_content :model :name :: STRING IN (
+      'terra_msg_event_model',
+      'terra-5_msg_event_model'
+    )
+
+{% if is_incremental() %}
+AND (
+  record_metadata :CreateTime :: INT / 1000
+) :: TIMESTAMP :: DATE >= (
+  SELECT
+    DATEADD('day', -1, MAX(system_created_at :: DATE))
+  FROM
+    {{ source(
+      'terra_dbt',
+      'msg_events'
+    ) }}
+)
+{% endif %}
+)
+SELECT
+  (
+    record_metadata :CreateTime :: INT / 1000
+  ) :: TIMESTAMP AS system_created_at,
+  t.value :blockchain :: STRING AS blockchain,
+  t.value :block_id :: bigint AS block_id,
+  t.value :block_timestamp :: TIMESTAMP AS block_timestamp,
+  t.value :chain_id :: STRING AS chain_id,
+  t.value :tx_id :: STRING AS tx_id,
+  t.value :tx_module :: STRING AS tx_module,
+  t.value :tx_status :: STRING AS tx_status,
+  t.value :tx_type :: STRING AS tx_type,
+  t.value :msg_index :: INTEGER AS msg_index,
+  t.value :msg_type :: STRING AS msg_type,
+  t.value :msg_module :: STRING AS msg_module,
+  t.value :event_type :: STRING AS event_type,
+  t.value :event_index :: INTEGER AS event_index,
+  t.value :event_attributes :: OBJECT AS event_attributes
+FROM
+  base_tables,
+  LATERAL FLATTEN(
+    input => record_content :results
+  ) t

--- a/models/terra/terra_dbt__msgs.sql
+++ b/models/terra/terra_dbt__msgs.sql
@@ -1,33 +1,54 @@
-{{ 
-  config(
-    materialized='incremental',
-    unique_key='chain_id || block_id || tx_id || msg_index', 
-    incremental_strategy='delete+insert',
-    tags=['snowflake', 'terra_silver', 'terra_msgs']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  unique_key = 'chain_id || block_id || tx_id || msg_index',
+  incremental_strategy = 'delete+insert',
+  tags = ['snowflake', 'terra_silver', 'terra_msgs']
+) }}
 
-with base_tables as (
-  select *
-  from {{source('bronze', 'prod_terra_sink_645110886')}}
-  where record_content:model:name::string = 'terra_msg_model'
-  {% if is_incremental() %}
-        AND (record_metadata:CreateTime::int/1000)::timestamp::date >= (select dateadd('day',-1,max(system_created_at::date)) from {{source('terra_dbt', 'msgs')}})
-  {% endif %}
-  )
+WITH base_tables AS (
 
-select (record_metadata:CreateTime::int/1000)::timestamp as system_created_at,
-      t.value:blockchain::string as blockchain,
-      t.value:block_id::bigint as block_id,
-      t.value:block_timestamp::timestamp as block_timestamp,
-      t.value:chain_id::string as chain_id,
-      t.value:tx_id::string as tx_id,
-      t.value:tx_type::string as tx_type,
-      t.value:tx_status::string as tx_status,
-      t.value:tx_module::string as tx_module,
-      t.value:msg_index::integer as msg_index,
-      t.value:msg_type::string as msg_type,
-      t.value:msg_module::string as msg_module,
-      t.value:msg_value::variant as msg_value
-from base_tables
-,lateral flatten(input => record_content:results) t
+  SELECT
+    *
+  FROM
+    {{ source(
+      'bronze',
+      'prod_terra_sink_645110886'
+    ) }}
+  WHERE
+    record_content :model :name :: STRING IN ('terra_msg_model', '')
+
+{% if is_incremental() %}
+AND (
+  record_metadata :CreateTime :: INT / 1000
+) :: TIMESTAMP :: DATE >= (
+  SELECT
+    DATEADD('day', -1, MAX(system_created_at :: DATE))
+  FROM
+    {{ source(
+      'terra_dbt',
+      'msgs'
+    ) }}
+)
+{% endif %}
+)
+SELECT
+  (
+    record_metadata :CreateTime :: INT / 1000
+  ) :: TIMESTAMP AS system_created_at,
+  t.value :blockchain :: STRING AS blockchain,
+  t.value :block_id :: bigint AS block_id,
+  t.value :block_timestamp :: TIMESTAMP AS block_timestamp,
+  t.value :chain_id :: STRING AS chain_id,
+  t.value :tx_id :: STRING AS tx_id,
+  t.value :tx_type :: STRING AS tx_type,
+  t.value :tx_status :: STRING AS tx_status,
+  t.value :tx_module :: STRING AS tx_module,
+  t.value :msg_index :: INTEGER AS msg_index,
+  t.value :msg_type :: STRING AS msg_type,
+  t.value :msg_module :: STRING AS msg_module,
+  t.value :msg_value :: variant AS msg_value
+FROM
+  base_tables,
+  LATERAL FLATTEN(
+    input => record_content :results
+  ) t

--- a/models/terra/terra_dbt__transactions.sql
+++ b/models/terra/terra_dbt__transactions.sql
@@ -1,35 +1,59 @@
-{{ 
-  config(
-    materialized='incremental',
-    unique_key='chain_id || block_id || tx_id', 
-    incremental_strategy='delete+insert',
-    tags=['snowflake', 'terra_silver', 'terra_transactions']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  unique_key = 'chain_id || block_id || tx_id',
+  incremental_strategy = 'delete+insert',
+  tags = ['snowflake', 'terra_silver', 'terra_transactions']
+) }}
 
-with base_tables as (
-  select *
-  from {{source('bronze', 'prod_terra_sink_645110886')}}
-  where record_content:model:name::string = 'terra_tx_model'
-  {% if is_incremental() %}
-        AND (record_metadata:CreateTime::int/1000)::timestamp::date >= (select dateadd('day',-1,max(system_created_at::date)) from {{source('terra_dbt', 'transactions')}})
-  {% endif %}
-  )
+WITH base_tables AS (
 
-select (record_metadata:CreateTime::int/1000)::timestamp as system_created_at,
-      t.value:blockchain::string as blockchain,
-      t.value:block_id::bigint as block_id,
-      t.value:block_timestamp::timestamp as block_timestamp,
-      t.value:chain_id::string as chain_id,
-      t.value:codespace::string as codespace,
-      t.value:tx_id::string as tx_id,
-      t.value:tx_type::string as tx_type,
-      t.value:tx_module::string as tx_module,
-      t.value:tx_status::string as tx_status,
-      t.value:tx_status_msg::string as tx_status_msg,
-      t.value:tx_code::integer as tx_code,
-      t.value:fee::array as fee,
-      t.value:gas_wanted::double as gas_wanted,
-      t.value:gas_used::double as gas_used
-from base_tables
-,lateral flatten(input => record_content:results) t
+  SELECT
+    *
+  FROM
+    {{ source(
+      'bronze',
+      'prod_terra_sink_645110886'
+    ) }}
+  WHERE
+    record_content :model :name :: STRING IN (
+      'terra_tx_model',
+      'terra-5_tx_model'
+    )
+
+{% if is_incremental() %}
+AND (
+  record_metadata :CreateTime :: INT / 1000
+) :: TIMESTAMP :: DATE >= (
+  SELECT
+    DATEADD('day', -1, MAX(system_created_at :: DATE))
+  FROM
+    {{ source(
+      'terra_dbt',
+      'transactions'
+    ) }}
+)
+{% endif %}
+)
+SELECT
+  (
+    record_metadata :CreateTime :: INT / 1000
+  ) :: TIMESTAMP AS system_created_at,
+  t.value :blockchain :: STRING AS blockchain,
+  t.value :block_id :: bigint AS block_id,
+  t.value :block_timestamp :: TIMESTAMP AS block_timestamp,
+  t.value :chain_id :: STRING AS chain_id,
+  t.value :codespace :: STRING AS codespace,
+  t.value :tx_id :: STRING AS tx_id,
+  t.value :tx_type :: STRING AS tx_type,
+  t.value :tx_module :: STRING AS tx_module,
+  t.value :tx_status :: STRING AS tx_status,
+  t.value :tx_status_msg :: STRING AS tx_status_msg,
+  t.value :tx_code :: INTEGER AS tx_code,
+  t.value :fee :: ARRAY AS fee,
+  t.value :gas_wanted :: DOUBLE AS gas_wanted,
+  t.value :gas_used :: DOUBLE AS gas_used
+FROM
+  base_tables,
+  LATERAL FLATTEN(
+    input => record_content :results
+  ) t

--- a/models/terra/terra_dbt__transitions.sql
+++ b/models/terra/terra_dbt__transitions.sql
@@ -1,29 +1,53 @@
-{{ 
-  config(
-    materialized='incremental',
-    unique_key='chain_id || block_id || index || transition_type || event', 
-    incremental_strategy='delete+insert',
-    tags=['snowflake', 'terra_silver', 'terra_transitions']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  unique_key = 'chain_id || block_id || index || transition_type || event',
+  incremental_strategy = 'delete+insert',
+  tags = ['snowflake', 'terra_silver', 'terra_transitions']
+) }}
 
-with base_tables as (
-  select *
-  from {{source('bronze', 'prod_terra_sink_645110886')}}
-  where record_content:model:name::string = 'terra_transition_model'
-  {% if is_incremental() %}
-        AND (record_metadata:CreateTime::int/1000)::timestamp::date >= (select dateadd('day',-1,max(system_created_at::date)) from {{source('terra_dbt', 'transitions')}})
-  {% endif %}
-  )
+WITH base_tables AS (
 
-select (record_metadata:CreateTime::int/1000)::timestamp as system_created_at,
-      t.value:blockchain::string as blockchain,
-      t.value:block_id::bigint as block_id,
-      t.value:block_timestamp::timestamp as block_timestamp,
-      t.value:chain_id::string as chain_id,
-      t.value:event::string as event,
-      t.value:index::integer as index,
-      t.value:transition_type::string as transition_type,
-      t.value:attributes::object as event_attributes
-from base_tables
-,lateral flatten(input => record_content:results) t
+  SELECT
+    *
+  FROM
+    {{ source(
+      'bronze',
+      'prod_terra_sink_645110886'
+    ) }}
+  WHERE
+    record_content :model :name :: STRING IN (
+      'terra_transition_model',
+      'terra-5_transition_model'
+    )
+
+{% if is_incremental() %}
+AND (
+  record_metadata :CreateTime :: INT / 1000
+) :: TIMESTAMP :: DATE >= (
+  SELECT
+    DATEADD('day', -1, MAX(system_created_at :: DATE))
+  FROM
+    {{ source(
+      'terra_dbt',
+      'transitions'
+    ) }}
+)
+{% endif %}
+)
+SELECT
+  (
+    record_metadata :CreateTime :: INT / 1000
+  ) :: TIMESTAMP AS system_created_at,
+  t.value :blockchain :: STRING AS blockchain,
+  t.value :block_id :: bigint AS block_id,
+  t.value :block_timestamp :: TIMESTAMP AS block_timestamp,
+  t.value :chain_id :: STRING AS chain_id,
+  t.value :event :: STRING AS event,
+  t.value :index :: INTEGER AS INDEX,
+  t.value :transition_type :: STRING AS transition_type,
+  t.value :attributes :: OBJECT AS event_attributes
+FROM
+  base_tables,
+  LATERAL FLATTEN(
+    input => record_content :results
+  ) t


### PR DESCRIPTION
Ensure sql models that source from bronze include Columbus-5 data

Models updated:
- sql_models.terra.terra_dbt__blocks
- sql_models.terra.terra_dbt__msg_events
- sql_models.terra.terra_dbt__msgs
- sql_models.terra.terra_dbt__transactions
- sql_models.terra.terra_dbt__transitions