### PR TITLE
fix-terra-unique-key-collisions-clustering

### DIFF
--- a/models/terra/anchor__bonds.sql
+++ b/models/terra/anchor__bonds.sql
@@ -1,88 +1,122 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'bonds', 'anchor_bonds']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'bonds', 'anchor_bonds']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    WHERE 1=1
-
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
-
-    GROUP BY 1,2,3
-
-),
-
-msgs AS (
-
-SELECT
-  m.blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  msg_value:sender::string AS sender,
-  msg_value:coins[0]:amount / POW(10,6) AS bonded_amount,
-  bonded_amount * price AS bonded_amount_usd,
-  msg_value:coins[0]:denom::string as bonded_currency,
-  msg_value:execute_msg:bond:validator::string AS validator,
-  msg_value:contract::string AS contract_address,
-  l.address AS contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', block_timestamp) = o.hour
- AND msg_value:coins[0]:denom::string = o.currency 
-
-WHERE msg_value:execute_msg:bond IS NOT NULL
-  AND tx_status = 'SUCCEEDED'
-  
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-
-events AS (
-
-SELECT 
-  tx_id,
-  event_attributes:"exchange_rate" / POW(10,6) AS minted_amount,
-  minted_amount * price AS minted_amount_usd, 
-  event_attributes:"denom"::string as minted_currency
-FROM {{ref('silver_terra__msg_events')}}
-
-LEFT OUTER JOIN prices o
-  ON date_trunc('hour', block_timestamp) = o.hour
-  AND event_attributes:"denom"::string = o.currency 
- 
-
-WHERE tx_id IN(SELECT tx_id FROM msgs)
-  AND tx_status = 'SUCCEEDED'
-  
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+msgs AS (
+  SELECT
+    m.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value :sender :: STRING AS sender,
+    msg_value :coins [0] :amount / pow(
+      10,
+      6
+    ) AS bonded_amount,
+    bonded_amount * price AS bonded_amount_usd,
+    msg_value :coins [0] :denom :: STRING AS bonded_currency,
+    msg_value :execute_msg :bond :validator :: STRING AS validator,
+    msg_value :contract :: STRING AS contract_address,
+    l.address AS contract_label
+  FROM
+    {{ ref('silver_terra__msgs') }}
+    m
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :contract :: STRING = l.address
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = o.hour
+    AND msg_value :coins [0] :denom :: STRING = o.currency
+  WHERE
+    msg_value :execute_msg :bond IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
-SELECT 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+events AS (
+  SELECT
+    tx_id,
+    event_attributes :"exchange_rate" / pow(
+      10,
+      6
+    ) AS minted_amount,
+    minted_amount * price AS minted_amount_usd,
+    event_attributes :"denom" :: STRING AS minted_currency
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = o.hour
+    AND event_attributes :"denom" :: STRING = o.currency
+  WHERE
+    tx_id IN(
+      SELECT
+        tx_id
+      FROM
+        msgs
+    )
+    AND tx_status = 'SUCCEEDED'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
+SELECT
   blockchain,
   chain_id,
   block_id,
@@ -95,7 +129,7 @@ SELECT
   validator,
   contract_address,
   contract_label
-FROM msgs m
-
-JOIN events e 
+FROM
+  msgs m
+  JOIN events e
   ON m.tx_id = e.tx_id

--- a/models/terra/anchor__borrows.sql
+++ b/models/terra/anchor__borrows.sql
@@ -1,55 +1,79 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'borrows']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'borrows']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
-
-    GROUP BY 1,2,3
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
-
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+)
 SELECT
   m.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:borrow_stable:borrow_amount / POW(10,6) as amount,
+  msg_value :sender :: STRING AS sender,
+  msg_value :execute_msg :borrow_stable :borrow_amount / pow(
+    10,
+    6
+  ) AS amount,
   amount * price AS amount_usd,
-  'uusd' as currency,
-  msg_value:contract::string as contract_address,
-  l.address as contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', block_timestamp) = o.hour
- AND 'uusd' = o.currency 
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-WHERE msg_value:execute_msg:borrow_stable IS NOT NULL -- Anchor Borrow 
-  AND msg_value:contract::string = 'terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s' -- Anchor Market Contract
+  'uusd' AS currency,
+  msg_value :contract :: STRING AS contract_address,
+  l.address AS contract_label
+FROM
+  {{ ref('silver_terra__msgs') }}
+  m
+  LEFT OUTER JOIN prices o
+  ON DATE_TRUNC(
+    'hour',
+    block_timestamp
+  ) = o.hour
+  AND 'uusd' = o.currency
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON msg_value :contract :: STRING = l.address
+WHERE
+  msg_value :execute_msg :borrow_stable IS NOT NULL -- Anchor Borrow
+  AND msg_value :contract :: STRING = 'terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s' -- Anchor Market Contract
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/anchor__burns.sql
+++ b/models/terra/anchor__burns.sql
@@ -1,54 +1,78 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'burns']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'burns']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
-
-SELECT 
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+)
+SELECT
   m.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:send:amount / POW(10,6) as amount,
+  msg_value :sender :: STRING AS sender,
+  msg_value :execute_msg :send :amount / pow(
+    10,
+    6
+  ) AS amount,
   amount * price AS amount_usd,
-  msg_value:contract::string as currency,
-  msg_value:execute_msg:send:contract::string as contract_address,
+  msg_value :contract :: STRING AS currency,
+  msg_value :execute_msg :send :contract :: STRING AS contract_address,
   l.address AS contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', block_timestamp) = o.hour
- AND msg_value:contract::string = o.currency 
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:execute_msg:send:contract::string = l.address
-
-WHERE msg_value:execute_msg:send:msg:unbond IS NOT NULL 
+FROM
+  {{ ref('silver_terra__msgs') }}
+  m
+  LEFT OUTER JOIN prices o
+  ON DATE_TRUNC(
+    'hour',
+    block_timestamp
+  ) = o.hour
+  AND msg_value :contract :: STRING = o.currency
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON msg_value :execute_msg :send :contract :: STRING = l.address
+WHERE
+  msg_value :execute_msg :send :msg :unbond IS NOT NULL
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/anchor__collateral.sql
+++ b/models/terra/anchor__collateral.sql
@@ -1,126 +1,168 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'collateral']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'collateral']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
 ),
-
 msgs AS (
+  SELECT
+    m.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    'withdraw' AS action,
+    msg_value :sender :: STRING AS sender,
+    msg_value :execute_msg :send :contract :: STRING AS contract_address,
+    l.address AS contract_label
+  FROM
+    {{ ref('silver_terra__msgs') }}
+    m
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :execute_msg :send :contract :: STRING = l.address
+  WHERE
+    msg_value :execute_msg :withdraw_collateral IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
-SELECT 
-  m.blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  'withdraw' as action,
-  msg_value:sender::string AS sender,
-  msg_value:execute_msg:send:contract::string AS contract_address,
-  l.address AS contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:execute_msg:send:contract::string = l.address
-
-WHERE msg_value:execute_msg:withdraw_collateral IS NOT NULL 
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
 ),
-
 events AS (
+  SELECT
+    tx_id,
+    event_attributes :collaterals [0] :amount / pow(
+      10,
+      6
+    ) AS amount,
+    amount * price AS amount_usd,
+    event_attributes :collaterals [0] :denom :: STRING AS currency
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    m
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = o.hour
+    AND event_attributes :collaterals [0] :denom :: STRING = o.currency
+  WHERE
+    tx_id IN(
+      SELECT
+        tx_id
+      FROM
+        msgs
+    )
+    AND event_type = 'from_contract'
+    AND event_attributes :collaterals IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
-  SELECT 
-  tx_id,
-  event_attributes:collaterals[0]:amount / POW(10,6) as amount,
-  amount * price AS amount_usd,
-  event_attributes:collaterals[0]:denom::string as currency
-FROM {{ref('silver_terra__msg_events')}} m
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', block_timestamp) = o.hour
- AND event_attributes:collaterals[0]:denom::string = o.currency 
-
-WHERE tx_id IN(SELECT tx_id FROM msgs)
-  AND event_type = 'from_contract'
-  AND event_attributes:collaterals IS NOT NULL
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-  
-)  
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
 SELECT
   blockchain,
   chain_id,
   block_id,
   block_timestamp,
   m.tx_id,
-  action as event_type,
+  action AS event_type,
   sender,
   amount,
   amount_usd,
   currency,
   contract_address,
   contract_label
-FROM msgs m
-
-JOIN events e 
+FROM
+  msgs m
+  JOIN events e
   ON m.tx_id = e.tx_id
-
-
-UNION 
-
-SELECT 
+UNION
+SELECT
   m.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  'provide' as event_type,
-  msg_value:sender::string AS sender,
-  msg_value:execute_msg:send:amount / POW(10,6) as amount,
+  'provide' AS event_type,
+  msg_value :sender :: STRING AS sender,
+  msg_value :execute_msg :send :amount / pow(
+    10,
+    6
+  ) AS amount,
   amount * price AS amount_usd,
-  msg_value:contract::string as currency,
-  msg_value:execute_msg:send:contract::string AS contract_address,
+  msg_value :contract :: STRING AS currency,
+  msg_value :execute_msg :send :contract :: STRING AS contract_address,
   l.address AS contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:execute_msg:send:contract::string = l.address
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', block_timestamp) = o.hour
- AND msg_value:contract::string = o.currency 
-
-WHERE msg_value:execute_msg:send:msg:deposit_collateral IS NOT NULL 
+FROM
+  {{ ref('silver_terra__msgs') }}
+  m
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON msg_value :execute_msg :send :contract :: STRING = l.address
+  LEFT OUTER JOIN prices o
+  ON DATE_TRUNC(
+    'hour',
+    block_timestamp
+  ) = o.hour
+  AND msg_value :contract :: STRING = o.currency
+WHERE
+  msg_value :execute_msg :send :msg :deposit_collateral IS NOT NULL
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/anchor__gov_staking.sql
+++ b/models/terra/anchor__gov_staking.sql
@@ -1,127 +1,170 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'anchor_gov']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'anchor_gov']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
-),
-
-stake_msgs AS (
-
-SELECT
-  t.blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:send:amount / POW(10,6) as amount,
-  amount * o.price AS amount_usd,
-  msg_value:contract::string as currency,
-  msg_value:execute_msg:send:contract::string as contract_address,
-  l.address AS contract_label 
-FROM {{ref('silver_terra__msgs')}} t
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', t.block_timestamp) = o.hour
- AND msg_value:contract::string = o.currency 
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:execute_msg:send:contract::string = l.address
-
-WHERE msg_value:execute_msg:send:msg:stake_voting_tokens IS NOT NULL 
-  AND msg_value:execute_msg:send:contract::string = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5'
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-
-stake_events AS (
-SELECT 
-  tx_id,
-  event_attributes:share as shares
-FROM {{ref('silver_terra__msg_events')}}
-WHERE tx_id IN(SELECT DISTINCT tx_id FROM stake_msgs)
-  AND event_type = 'from_contract'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+stake_msgs AS (
+  SELECT
+    t.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value :sender :: STRING AS sender,
+    msg_value :execute_msg :send :amount / pow(
+      10,
+      6
+    ) AS amount,
+    amount * o.price AS amount_usd,
+    msg_value :contract :: STRING AS currency,
+    msg_value :execute_msg :send :contract :: STRING AS contract_address,
+    l.address AS contract_label
+  FROM
+    {{ ref('silver_terra__msgs') }}
+    t
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = o.hour
+    AND msg_value :contract :: STRING = o.currency
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :execute_msg :send :contract :: STRING = l.address
+  WHERE
+    msg_value :execute_msg :send :msg :stake_voting_tokens IS NOT NULL
+    AND msg_value :execute_msg :send :contract :: STRING = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5'
+    AND tx_status = 'SUCCEEDED'
 
--- Staking 
-SELECT 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+stake_events AS (
+  SELECT
+    tx_id,
+    event_attributes :share AS shares
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+  WHERE
+    tx_id IN(
+      SELECT
+        DISTINCT tx_id
+      FROM
+        stake_msgs
+    )
+    AND event_type = 'from_contract'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+) -- Staking
+SELECT
   blockchain,
   chain_id,
   block_id,
   block_timestamp,
   m.tx_id,
-  'stake' as event_type,
+  'stake' AS event_type,
   sender,
   amount,
-  amount_usd,  
-  currency, 
+  amount_usd,
+  currency,
   shares,
   contract_address,
-  contract_label 
-FROM stake_msgs m 
-
-JOIN stake_events e 
+  contract_label
+FROM
+  stake_msgs m
+  JOIN stake_events e
   ON m.tx_id = e.tx_id
-
-UNION 
-
--- Unstaking
-
+UNION
+  -- Unstaking
 SELECT
   t.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  'unstake' as event_type,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:withdraw_voting_tokens:amount / POW(10,6) as amount,
+  'unstake' AS event_type,
+  msg_value :sender :: STRING AS sender,
+  msg_value :execute_msg :withdraw_voting_tokens :amount / pow(
+    10,
+    6
+  ) AS amount,
   amount * o.price AS amount_usd,
-  'terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76' as currency,
-  NULL as shares,
-  msg_value:contract::string as contract_address,
-  l.address as contract_label
-FROM {{ref('silver_terra__msgs')}} t
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', t.block_timestamp) = o.hour
- AND 'terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76' = o.currency 
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-WHERE msg_value:execute_msg:withdraw_voting_tokens IS NOT NULL
-  AND msg_value:contract::string = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5'
+  'terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76' AS currency,
+  NULL AS shares,
+  msg_value :contract :: STRING AS contract_address,
+  l.address AS contract_label
+FROM
+  {{ ref('silver_terra__msgs') }}
+  t
+  LEFT OUTER JOIN prices o
+  ON DATE_TRUNC(
+    'hour',
+    t.block_timestamp
+  ) = o.hour
+  AND 'terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76' = o.currency
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON msg_value :contract :: STRING = l.address
+WHERE
+  msg_value :execute_msg :withdraw_voting_tokens IS NOT NULL
+  AND msg_value :contract :: STRING = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5'
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/anchor__gov_submit_proposal.sql
+++ b/models/terra/anchor__gov_submit_proposal.sql
@@ -1,50 +1,75 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'anchor_gov']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'anchor_gov']
 ) }}
 
 WITH msgs AS (
-SELECT 
-  blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  msg_value:sender::string as creator,
-  msg_value:execute_msg:send:amount / POW(10,6) as amount,
-  msg_value:execute_msg:send:msg:create_poll:title::string as title,
-  msg_value:execute_msg:send:msg:create_poll:link::string as link,
-  msg_value:execute_msg:send:msg:create_poll:description::string as description,
-  msg_value:execute_msg:send:msg:create_poll:execute_msg:msg as msg,
-  msg_value:execute_msg:send:contract::string as contract_address
-FROM {{ref('silver_terra__msgs')}}
-WHERE msg_value:execute_msg:send:msg:create_poll IS NOT NULL 
-  AND msg_value:execute_msg:send:contract::string = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5' -- ANC Governance 
-  AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-),
+  SELECT
+    blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value :sender :: STRING AS creator,
+    msg_value :execute_msg :send :amount / pow(
+      10,
+      6
+    ) AS amount,
+    msg_value :execute_msg :send :msg :create_poll :title :: STRING AS title,
+    msg_value :execute_msg :send :msg :create_poll :link :: STRING AS link,
+    msg_value :execute_msg :send :msg :create_poll :description :: STRING AS description,
+    msg_value :execute_msg :send :msg :create_poll :execute_msg :msg AS msg,
+    msg_value :execute_msg :send :contract :: STRING AS contract_address
+  FROM
+    {{ ref('silver_terra__msgs') }}
+  WHERE
+    msg_value :execute_msg :send :msg :create_poll IS NOT NULL
+    AND msg_value :execute_msg :send :contract :: STRING = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5' -- ANC Governance
+    AND tx_status = 'SUCCEEDED'
 
-events AS (
-SELECT 
-  tx_id,
-  COALESCE(to_timestamp(event_attributes:end_time),event_attributes:end_height) as end_time,
-  event_attributes:poll_id as poll_id
-FROM {{ref('silver_terra__msg_events')}}
-WHERE tx_id IN(select tx_id from msgs)
-  AND event_type = 'from_contract'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+),
+events AS (
+  SELECT
+    tx_id,
+    COALESCE(TO_TIMESTAMP(event_attributes :end_time), event_attributes :end_height) AS end_time,
+    event_attributes :poll_id AS poll_id
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+  WHERE
+    tx_id IN(
+      SELECT
+        tx_id
+      FROM
+        msgs
+    )
+    AND event_type = 'from_contract'
 
-SELECT 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
+SELECT
   m.blockchain,
   chain_id,
   block_id,
@@ -52,7 +77,7 @@ SELECT
   m.tx_id,
   poll_id,
   end_time,
-  m.creator, 
+  m.creator,
   amount,
   title,
   link,
@@ -60,10 +85,9 @@ SELECT
   msg,
   contract_address,
   l.address AS contract_label
-FROM msgs m 
-
-JOIN events e 
+FROM
+  msgs m
+  JOIN events e
   ON m.tx_id = e.tx_id
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON contract_address = l.address
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON contract_address = l.address

--- a/models/terra/anchor__gov_vote.sql
+++ b/models/terra/anchor__gov_vote.sql
@@ -1,32 +1,43 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'anchor_gov']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'anchor_gov']
 ) }}
 
-SELECT 
+SELECT
   m.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  msg_value:sender::string as voter,
-  msg_value:execute_msg:cast_vote:poll_id as poll_id,
-  msg_value:execute_msg:cast_vote:vote::string as vote,
-  msg_value:execute_msg:cast_vote:amount / POW(10,6) as balance,
-  msg_value:contract::string as contract_address,
-  l.address as contract_label 
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-WHERE msg_value:contract::string = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5' -- ANC Governance
-  AND msg_value:execute_msg:cast_vote IS NOT NULL 
+  msg_value :sender :: STRING AS voter,
+  msg_value :execute_msg :cast_vote :poll_id AS poll_id,
+  msg_value :execute_msg :cast_vote :vote :: STRING AS vote,
+  msg_value :execute_msg :cast_vote :amount / pow(
+    10,
+    6
+  ) AS balance,
+  msg_value :contract :: STRING AS contract_address,
+  l.address AS contract_label
+FROM
+  {{ ref('silver_terra__msgs') }}
+  m
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON msg_value :contract :: STRING = l.address
+WHERE
+  msg_value :contract :: STRING = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5' -- ANC Governance
+  AND msg_value :execute_msg :cast_vote IS NOT NULL
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/anchor__liquidations.sql
+++ b/models/terra/anchor__liquidations.sql
@@ -1,91 +1,130 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'liquidations']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'liquidations']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
-),
-
-msgs AS (
-
-SELECT 
-  m.blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  msg_value:execute_msg:liquidate_collateral:borrower::string AS borrower,
-  msg_value:contract::string as contract_address,
-  l.address as contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-WHERE msg_value:contract::string = 'terra1tmnqgvg567ypvsvk6rwsga3srp7e3lg6u0elp8'
-  AND msg_value:execute_msg:liquidate_collateral IS NOT NULL 
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-), 
-
-events AS (
-
-SELECT 
-  tx_id,
-  event_attributes:liquidator::string AS liquidator,
-  event_attributes:collateral_amount / POW(10,6) AS liquidated_amount,
-  liquidated_amount * l.price AS liquidated_amount_usd,
-  event_attributes:collateral_token::string as liquidated_currency,
-  event_attributes:"1_repay_amount" / POW(10,6) as repay_amount,
-  event_attributes:"1_borrower"::string as borrower,
-  repay_amount * r.price as repay_amount_usd,
-  event_attributes:stable_denom::string as repay_currency,
-  event_attributes:bid_fee / POW(10,6) AS bid_fee
-FROM {{ref('silver_terra__msg_events')}}
-
-LEFT OUTER JOIN prices l
- ON date_trunc('hour', block_timestamp) = l.hour
- AND event_attributes:collateral_token::string = l.currency 
-
-LEFT OUTER JOIN prices r
- ON date_trunc('hour', block_timestamp) = r.hour
- AND event_attributes:stable_denom::string = r.currency 
-
-WHERE event_type = 'from_contract'
-  AND tx_id IN(SELECT tx_id FROM msgs)
-  AND tx_status = 'SUCCEEDED'
-  AND event_attributes:"0_action"::string = 'liquidate_collateral'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+msgs AS (
+  SELECT
+    m.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value :execute_msg :liquidate_collateral :borrower :: STRING AS borrower,
+    msg_value :contract :: STRING AS contract_address,
+    l.address AS contract_label
+  FROM
+    {{ ref('silver_terra__msgs') }}
+    m
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :contract :: STRING = l.address
+  WHERE
+    msg_value :contract :: STRING = 'terra1tmnqgvg567ypvsvk6rwsga3srp7e3lg6u0elp8'
+    AND msg_value :execute_msg :liquidate_collateral IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
-SELECT 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+events AS (
+  SELECT
+    tx_id,
+    event_attributes :liquidator :: STRING AS liquidator,
+    event_attributes :collateral_amount / pow(
+      10,
+      6
+    ) AS liquidated_amount,
+    liquidated_amount * l.price AS liquidated_amount_usd,
+    event_attributes :collateral_token :: STRING AS liquidated_currency,
+    event_attributes :"1_repay_amount" / pow(
+      10,
+      6
+    ) AS repay_amount,
+    event_attributes :"1_borrower" :: STRING AS borrower,
+    repay_amount * r.price AS repay_amount_usd,
+    event_attributes :stable_denom :: STRING AS repay_currency,
+    event_attributes :bid_fee / pow(
+      10,
+      6
+    ) AS bid_fee
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    LEFT OUTER JOIN prices l
+    ON DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = l.hour
+    AND event_attributes :collateral_token :: STRING = l.currency
+    LEFT OUTER JOIN prices r
+    ON DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = r.hour
+    AND event_attributes :stable_denom :: STRING = r.currency
+  WHERE
+    event_type = 'from_contract'
+    AND tx_id IN(
+      SELECT
+        tx_id
+      FROM
+        msgs
+    )
+    AND tx_status = 'SUCCEEDED'
+    AND event_attributes :"0_action" :: STRING = 'liquidate_collateral'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
+SELECT
   blockchain,
   chain_id,
   block_id,
@@ -102,7 +141,8 @@ SELECT
   repay_currency,
   contract_address,
   contract_label
-FROM msgs m 
-
-JOIN events e 
-  ON m.tx_id = e.tx_id AND m.borrower = e.borrower
+FROM
+  msgs m
+  JOIN events e
+  ON m.tx_id = e.tx_id
+  AND m.borrower = e.borrower

--- a/models/terra/anchor__redeem.sql
+++ b/models/terra/anchor__redeem.sql
@@ -1,54 +1,78 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'redeem']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'redeem']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
-
-SELECT 
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+)
+SELECT
   m.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:send:amount / POW(10,6) as amount,
+  msg_value :sender :: STRING AS sender,
+  msg_value :execute_msg :send :amount / pow(
+    10,
+    6
+  ) AS amount,
   amount * price AS amount_usd,
-  msg_value:contract::string as currency,
-  msg_value:execute_msg:send:contract::string as contract_address,
+  msg_value :contract :: STRING AS currency,
+  msg_value :execute_msg :send :contract :: STRING AS contract_address,
   l.address AS contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:execute_msg:send:contract::string = l.address
-
-LEFT OUTER JOIN prices r
- ON date_trunc('hour', block_timestamp) = hour
- AND msg_value:contract::string = r.currency 
-
-WHERE msg_value:execute_msg:send:msg:redeem_stable IS NOT NULL 
+FROM
+  {{ ref('silver_terra__msgs') }}
+  m
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON msg_value :execute_msg :send :contract :: STRING = l.address
+  LEFT OUTER JOIN prices r
+  ON DATE_TRUNC(
+    'hour',
+    block_timestamp
+  ) = HOUR
+  AND msg_value :contract :: STRING = r.currency
+WHERE
+  msg_value :execute_msg :send :msg :redeem_stable IS NOT NULL
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/anchor__repay.sql
+++ b/models/terra/anchor__repay.sql
@@ -1,54 +1,78 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'repay']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'repay']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
-
-SELECT 
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+)
+SELECT
   m.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  msg_value:sender::string as sender,
-  msg_value:coins[0]:amount / POW(10,6) as amount,
+  msg_value :sender :: STRING AS sender,
+  msg_value :coins [0] :amount / pow(
+    10,
+    6
+  ) AS amount,
   amount * price AS amount_usd,
-  msg_value:coins[0]:denom::string as currency,
-  msg_value:contract::string as contract_address,
+  msg_value :coins [0] :denom :: STRING AS currency,
+  msg_value :contract :: STRING AS contract_address,
   l.address AS contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-LEFT OUTER JOIN prices r
- ON date_trunc('hour', block_timestamp) = hour
- AND msg_value:coins[0]:denom::string = r.currency 
-
-WHERE msg_value:execute_msg:repay_stable IS NOT NULL 
+FROM
+  {{ ref('silver_terra__msgs') }}
+  m
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON msg_value :contract :: STRING = l.address
+  LEFT OUTER JOIN prices r
+  ON DATE_TRUNC(
+    'hour',
+    block_timestamp
+  ) = HOUR
+  AND msg_value :coins [0] :denom :: STRING = r.currency
+WHERE
+  msg_value :execute_msg :repay_stable IS NOT NULL
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/anchor__reward_claims.sql
+++ b/models/terra/anchor__reward_claims.sql
@@ -1,123 +1,163 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'anchor', 'reward_claims']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor', 'reward_claims']
 ) }}
+
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
-),
-
-withdraw_msgs AS (
-
-SELECT 
-  tx_id,
-  msg_index,
-  msg_value:contract::string as claim_0_contract
-FROM {{ref('silver_terra__msgs')}}
-WHERE msg_value:execute_msg:withdraw IS NOT NULL
-  AND msg_index = 0
-  AND msg_value:contract::string = 'terra1897an2xux840p9lrh6py3ryankc6mspw49xse3'
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-
-claim_msgs AS (
-
-SELECT 
-  tx_id,
-  msg_index,
-  msg_value:sender::string as sender,
-  msg_value:contract::string as claim_1_contract
-FROM {{ref('silver_terra__msgs')}}
-WHERE msg_value:execute_msg:claim_rewards IS NOT NULL
-  AND msg_index = 1
-  AND msg_value:contract::string = 'terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s'
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-  
-),
-
-withdraw AS (  
-
-SELECT 
-  m.tx_id,
-  claim_0_contract,
-  event_attributes:"0_amount" / POW(10,6) as claim_0_amount,
-  event_attributes:"1_contract_address"::string as claim_0_currency
-FROM {{ref('silver_terra__msg_events')}} e
-  
-JOIN withdraw_msgs m 
-  ON m.tx_id = e.tx_id
-  AND m.msg_index = e.msg_index
-
-WHERE event_type = 'from_contract'  
-  AND tx_status = 'SUCCEEDED'
-  AND event_attributes:"0_action"::string = 'withdraw'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-  
-),
-
-claim AS (
-
-SELECT 
-  blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  m.tx_id,
-  sender,
-  claim_1_contract,
-  event_attributes:claim_amount / POW(10,6) as claim_1_amount,
-  event_attributes:"2_contract_address"::string as claim_1_currency
-FROM {{ref('silver_terra__msg_events')}} e
-  
-JOIN claim_msgs m 
-  ON m.tx_id = e.tx_id
-  AND m.msg_index = e.msg_index
-  
-WHERE event_type = 'from_contract'
-  AND tx_status = 'SUCCEEDED'
-  AND event_attributes:"0_action"::string = 'claim_rewards'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-  
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+withdraw_msgs AS (
+  SELECT
+    tx_id,
+    msg_index,
+    msg_value :contract :: STRING AS claim_0_contract
+  FROM
+    {{ ref('silver_terra__msgs') }}
+  WHERE
+    msg_value :execute_msg :withdraw IS NOT NULL
+    AND msg_index = 0
+    AND msg_value :contract :: STRING = 'terra1897an2xux840p9lrh6py3ryankc6mspw49xse3'
+    AND tx_status = 'SUCCEEDED'
 
-SELECT 
-  c.blockchain,
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+claim_msgs AS (
+  SELECT
+    tx_id,
+    msg_index,
+    msg_value :sender :: STRING AS sender,
+    msg_value :contract :: STRING AS claim_1_contract
+  FROM
+    {{ ref('silver_terra__msgs') }}
+  WHERE
+    msg_value :execute_msg :claim_rewards IS NOT NULL
+    AND msg_index = 1
+    AND msg_value :contract :: STRING = 'terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s'
+    AND tx_status = 'SUCCEEDED'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+withdraw AS (
+  SELECT
+    m.tx_id,
+    claim_0_contract,
+    event_attributes :"0_amount" / pow(
+      10,
+      6
+    ) AS claim_0_amount,
+    event_attributes :"1_contract_address" :: STRING AS claim_0_currency
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    e
+    JOIN withdraw_msgs m
+    ON m.tx_id = e.tx_id
+    AND m.msg_index = e.msg_index
+  WHERE
+    event_type = 'from_contract'
+    AND tx_status = 'SUCCEEDED'
+    AND event_attributes :"0_action" :: STRING = 'withdraw'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+claim AS (
+  SELECT
+    blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    m.tx_id,
+    sender,
+    claim_1_contract,
+    event_attributes :claim_amount / pow(
+      10,
+      6
+    ) AS claim_1_amount,
+    event_attributes :"2_contract_address" :: STRING AS claim_1_currency
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    e
+    JOIN claim_msgs m
+    ON m.tx_id = e.tx_id
+    AND m.msg_index = e.msg_index
+  WHERE
+    event_type = 'from_contract'
+    AND tx_status = 'SUCCEEDED'
+    AND event_attributes :"0_action" :: STRING = 'claim_rewards'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
+SELECT
+  C.blockchain,
   chain_id,
   block_id,
   block_timestamp,
-  c.tx_id,
+  C.tx_id,
   sender,
   claim_0_amount,
   claim_0_amount * p0.price AS claim_0_amount_usd,
@@ -129,21 +169,23 @@ SELECT
   claim_1_currency,
   claim_1_contract,
   l1.address AS claim_1_contract_label
-FROM claim c 
-
-JOIN withdraw w 
-  ON c.tx_id = w.tx_id
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l0
-ON claim_0_contract = l0.address
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l1
-ON claim_1_contract = l1.address
-
-LEFT OUTER JOIN prices p0
- ON date_trunc('hour', block_timestamp) = p0.hour
- AND claim_0_currency = p0.currency 
-
- LEFT OUTER JOIN prices p1
- ON date_trunc('hour', block_timestamp) = p1.hour
- AND claim_1_currency = p1.currency 
+FROM
+  claim C
+  JOIN withdraw w
+  ON C.tx_id = w.tx_id
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l0
+  ON claim_0_contract = l0.address
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l1
+  ON claim_1_contract = l1.address
+  LEFT OUTER JOIN prices p0
+  ON DATE_TRUNC(
+    'hour',
+    block_timestamp
+  ) = p0.hour
+  AND claim_0_currency = p0.currency
+  LEFT OUTER JOIN prices p1
+  ON DATE_TRUNC(
+    'hour',
+    block_timestamp
+  ) = p1.hour
+  AND claim_1_currency = p1.currency

--- a/models/terra/anchor_dbt__stake.sql
+++ b/models/terra/anchor_dbt__stake.sql
@@ -1,84 +1,113 @@
-{{ 
-  config(
-    materialized='incremental', 
-    sort='block_timestamp', 
-    unique_key='block_id', 
-    incremental_strategy='delete+insert',
-    cluster_by=['block_timestamp'],
-    tags=['snowflake', 'terra', 'anchor_dbt', 'stake']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  sort = 'block_timestamp',
+  unique_key = "block_id",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'anchor_dbt', 'stake']
+) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
-),
-
-msgs AS (
-
-SELECT 
-  m.blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  'unstake' as action,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:withdraw_voting_tokens:amount / POW(10,6) as amount,
-  msg_value:contract::string as contract_address,
-  l.address AS contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-WHERE msg_value:execute_msg:withdraw_voting_tokens IS NOT NULL 
-  AND msg_value:contract::string = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5'
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-  
-),
-
-events AS (
-
-SELECT
-  tx_id, 
-  price,
-  event_attributes:"0_contract_address"::string as currency
-FROM {{ref('silver_terra__msg_events')}}
-
-LEFT OUTER JOIN prices r
- ON date_trunc('hour', block_timestamp) = hour
- AND event_attributes:"0_contract_address"::string = r.currency 
-
-WHERE event_type = 'execute_contract'
-  AND tx_id IN(SELECT tx_id FROM msgs) 
-  AND msg_index = 0
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+msgs AS (
+  SELECT
+    m.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    'unstake' AS action,
+    msg_value :sender :: STRING AS sender,
+    msg_value :execute_msg :withdraw_voting_tokens :amount / pow(
+      10,
+      6
+    ) AS amount,
+    msg_value :contract :: STRING AS contract_address,
+    l.address AS contract_label
+  FROM
+    {{ ref('silver_terra__msgs') }}
+    m
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :contract :: STRING = l.address
+  WHERE
+    msg_value :execute_msg :withdraw_voting_tokens IS NOT NULL
+    AND msg_value :contract :: STRING = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5'
+    AND tx_status = 'SUCCEEDED'
 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+events AS (
+  SELECT
+    tx_id,
+    price,
+    event_attributes :"0_contract_address" :: STRING AS currency
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    LEFT OUTER JOIN prices r
+    ON DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = HOUR
+    AND event_attributes :"0_contract_address" :: STRING = r.currency
+  WHERE
+    event_type = 'execute_contract'
+    AND tx_id IN(
+      SELECT
+        tx_id
+      FROM
+        msgs
+    )
+    AND msg_index = 0
+    AND tx_status = 'SUCCEEDED'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
 SELECT
   blockchain,
   chain_id,
@@ -92,39 +121,50 @@ SELECT
   currency,
   contract_address,
   contract_label
-FROM msgs m
-
-JOIN events e 
+FROM
+  msgs m
+  JOIN events e
   ON m.tx_id = e.tx_id
-
 UNION
-
-SELECT 
+SELECT
   m.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  'stake' as action,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:send:amount / POW(10,6) as amount,
+  'stake' AS action,
+  msg_value :sender :: STRING AS sender,
+  msg_value :execute_msg :send :amount / pow(
+    10,
+    6
+  ) AS amount,
   amount * price AS amount_usd,
-  msg_value:contract::string as currency,
-  msg_value:execute_msg:send:contract::string as contract_address,
+  msg_value :contract :: STRING AS currency,
+  msg_value :execute_msg :send :contract :: STRING AS contract_address,
   l.address AS contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:execute_msg:send:contract::string = l.address
-
-LEFT OUTER JOIN prices r
- ON date_trunc('hour', block_timestamp) = hour
- AND msg_value:contract::string = r.currency 
-
-WHERE msg_value:execute_msg:send:msg:stake_voting_tokens IS NOT NULL 
-  AND msg_value:execute_msg:send:contract::string = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5'
+FROM
+  {{ ref('silver_terra__msgs') }}
+  m
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON msg_value :execute_msg :send :contract :: STRING = l.address
+  LEFT OUTER JOIN prices r
+  ON DATE_TRUNC(
+    'hour',
+    block_timestamp
+  ) = HOUR
+  AND msg_value :contract :: STRING = r.currency
+WHERE
+  msg_value :execute_msg :send :msg :stake_voting_tokens IS NOT NULL
+  AND msg_value :execute_msg :send :contract :: STRING = 'terra1f32xyep306hhcxxxf7mlyh0ucggc00rm2s9da5'
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/mirror__close_collateral.sql
+++ b/models/terra/mirror__close_collateral.sql
@@ -1,8 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'block_id || tx_id',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp', 'block_id'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'mirror', 'mirror_close_collateral']
 ) }}
 

--- a/models/terra/mirror__close_short_farm.sql
+++ b/models/terra/mirror__close_short_farm.sql
@@ -1,186 +1,263 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'mirror', 'short_farm']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'mirror', 'short_farm']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
-),
-
-prices_backup AS (
-
-  SELECT 
-      date_trunc('day', block_timestamp) as day,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
-
-    GROUP BY 1,2,3
-
-),
-
-tx AS (
-
-SELECT 
-  blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  msg_value
-FROM {{ref('silver_terra__msgs')}}
-WHERE msg_value:execute_msg:send:msg:burn IS NOT NULL
-  AND msg_value:execute_msg:send:contract::string = 'terra1wfz7h3aqf4cjmjcvc6s8lxdhh7k30nkczyf0mj'
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-
-event_tx AS (
-
-SELECT 
-  block_timestamp,
-  tx_id,
-  event_attributes
-FROM {{ref('silver_terra__msg_events')}}
-WHERE tx_id IN(select tx_id from tx)
-  AND event_type = 'from_contract'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-
-msgs as (
-
-SELECT
-  t.blockchain,
-  chain_id,
-  block_id,
-  block_timestamp, 
-  tx_id,
-  msg_value:execute_msg:send:msg:burn:position_idx as collateral_id,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:send:contract::string as contract_address,
-  l.address AS contract_label
-FROM tx t
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:execute_msg:send:contract::string = l.address
-
-),
-
-withdraw_events AS (
-
-SELECT 
-  tx_id,
-  
-  event_attributes:withdraw_amount[0]:amount / POW(10,6) AS withdraw_amount,
-  withdraw_amount * coalesce(o.price,o_b.price) AS withdraw_amount_usd,
-  event_attributes:withdraw_amount[0]:denom::string AS withdraw_currency,
-  
-  event_attributes:unlocked_amount[0]:amount / POW(10,6) AS unlocked_amount,
-  unlocked_amount * coalesce(i.price,i_b.price) AS unlocked_amount_usd,
-  event_attributes:unlocked_amount[0]:denom::string AS unlocked_currency,
-  
-  (event_attributes:"0_tax_amount"[0]:amount + event_attributes:"1_tax_amount"[0]:amount) / POW(10,6) AS tax_amount,
-  tax_amount * coalesce(a.price,a_b.price) AS tax_amount_usd,
-  event_attributes:"0_tax_amount"[0]:denom::string AS tax_currency
-  
-FROM event_tx t
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', t.block_timestamp) = o.hour
- AND t.event_attributes:withdraw_amount[0]:denom::string = o.currency 
-
-LEFT OUTER JOIN prices i
- ON date_trunc('hour', t.block_timestamp) = i.hour
- AND t.event_attributes:unlocked_amount[0]:denom::string = i.currency  
-
-LEFT OUTER JOIN prices a
- ON date_trunc('hour', t.block_timestamp) = a.hour
- AND t.event_attributes:"0_tax_amount"[0]:denom::string = a.currency  
-
-LEFT OUTER JOIN prices_backup o_b
- ON date_trunc('day', t.block_timestamp) = o_b.day
- AND t.event_attributes:withdraw_amount[0]:denom::string = o_b.currency 
-
-LEFT OUTER JOIN prices_backup i_b
- ON date_trunc('day', t.block_timestamp) = i_b.day
- AND t.event_attributes:unlocked_amount[0]:denom::string = i_b.currency  
-
-LEFT OUTER JOIN prices_backup a_b
- ON date_trunc('day', t.block_timestamp) = a_b.day
- AND t.event_attributes:"0_tax_amount"[0]:denom::string = a_b.currency  
-
-WHERE event_attributes:withdraw_amount IS NOT NULL 
-
-),
-
-burn_events AS (
-
-SELECT 
-  tx_id,
-  
-  event_attributes:burn_amount[0]:amount / POW(10,6) AS burn_amount,
-  burn_amount * coalesce(o.price,o_b.price) AS burn_amount_usd,
-  event_attributes:burn_amount[0]:denom::string AS burn_currency,  
-  
-  event_attributes:protocol_fee[0]:amount / POW(10,6) AS protocol_fee_amount,
-  protocol_fee_amount * coalesce(i.price,i_b.price) AS protocol_fee_amount_usd,
-  event_attributes:protocol_fee[0]:denom::string AS protocol_fee_currency
-FROM event_tx t
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', t.block_timestamp) = o.hour
- AND t.event_attributes:burn_amount[0]:denom::string = o.currency 
-
-LEFT OUTER JOIN prices i
- ON date_trunc('hour', t.block_timestamp) = i.hour
- AND t.event_attributes:protocol_fee[0]:denom::string = i.currency  
-
-LEFT OUTER JOIN prices_backup o_b
- ON date_trunc('day', t.block_timestamp) = o_b.day
- AND t.event_attributes:burn_amount[0]:denom::string = o_b.currency 
-
-LEFT OUTER JOIN prices_backup i_b
- ON date_trunc('day', t.block_timestamp) = i_b.day
- AND t.event_attributes:protocol_fee[0]:denom::string = i_b.currency  
-
-WHERE event_attributes:burn_amount IS NOT NULL
-  
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+prices_backup AS (
+  SELECT
+    DATE_TRUNC(
+      'day',
+      block_timestamp
+    ) AS DAY,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-SELECT 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+tx AS (
+  SELECT
+    blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value
+  FROM
+    {{ ref('silver_terra__msgs') }}
+  WHERE
+    msg_value :execute_msg :send :msg :burn IS NOT NULL
+    AND msg_value :execute_msg :send :contract :: STRING = 'terra1wfz7h3aqf4cjmjcvc6s8lxdhh7k30nkczyf0mj'
+    AND tx_status = 'SUCCEEDED'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+event_tx AS (
+  SELECT
+    block_timestamp,
+    tx_id,
+    event_attributes
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+  WHERE
+    tx_id IN(
+      SELECT
+        tx_id
+      FROM
+        tx
+    )
+    AND event_type = 'from_contract'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+msgs AS (
+  SELECT
+    t.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value :execute_msg :send :msg :burn :position_idx AS collateral_id,
+    msg_value :sender :: STRING AS sender,
+    msg_value :execute_msg :send :contract :: STRING AS contract_address,
+    l.address AS contract_label
+  FROM
+    tx t
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :execute_msg :send :contract :: STRING = l.address
+),
+withdraw_events AS (
+  SELECT
+    tx_id,
+    event_attributes :withdraw_amount [0] :amount / pow(
+      10,
+      6
+    ) AS withdraw_amount,
+    withdraw_amount * COALESCE(
+      o.price,
+      o_b.price
+    ) AS withdraw_amount_usd,
+    event_attributes :withdraw_amount [0] :denom :: STRING AS withdraw_currency,
+    event_attributes :unlocked_amount [0] :amount / pow(
+      10,
+      6
+    ) AS unlocked_amount,
+    unlocked_amount * COALESCE(
+      i.price,
+      i_b.price
+    ) AS unlocked_amount_usd,
+    event_attributes :unlocked_amount [0] :denom :: STRING AS unlocked_currency,
+    (
+      event_attributes :"0_tax_amount" [0] :amount + event_attributes :"1_tax_amount" [0] :amount
+    ) / pow(
+      10,
+      6
+    ) AS tax_amount,
+    tax_amount * COALESCE(
+      A.price,
+      a_b.price
+    ) AS tax_amount_usd,
+    event_attributes :"0_tax_amount" [0] :denom :: STRING AS tax_currency
+  FROM
+    event_tx t
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = o.hour
+    AND t.event_attributes :withdraw_amount [0] :denom :: STRING = o.currency
+    LEFT OUTER JOIN prices i
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = i.hour
+    AND t.event_attributes :unlocked_amount [0] :denom :: STRING = i.currency
+    LEFT OUTER JOIN prices A
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = A.hour
+    AND t.event_attributes :"0_tax_amount" [0] :denom :: STRING = A.currency
+    LEFT OUTER JOIN prices_backup o_b
+    ON DATE_TRUNC(
+      'day',
+      t.block_timestamp
+    ) = o_b.day
+    AND t.event_attributes :withdraw_amount [0] :denom :: STRING = o_b.currency
+    LEFT OUTER JOIN prices_backup i_b
+    ON DATE_TRUNC(
+      'day',
+      t.block_timestamp
+    ) = i_b.day
+    AND t.event_attributes :unlocked_amount [0] :denom :: STRING = i_b.currency
+    LEFT OUTER JOIN prices_backup a_b
+    ON DATE_TRUNC(
+      'day',
+      t.block_timestamp
+    ) = a_b.day
+    AND t.event_attributes :"0_tax_amount" [0] :denom :: STRING = a_b.currency
+  WHERE
+    event_attributes :withdraw_amount IS NOT NULL
+),
+burn_events AS (
+  SELECT
+    tx_id,
+    event_attributes :burn_amount [0] :amount / pow(
+      10,
+      6
+    ) AS burn_amount,
+    burn_amount * COALESCE(
+      o.price,
+      o_b.price
+    ) AS burn_amount_usd,
+    event_attributes :burn_amount [0] :denom :: STRING AS burn_currency,
+    event_attributes :protocol_fee [0] :amount / pow(
+      10,
+      6
+    ) AS protocol_fee_amount,
+    protocol_fee_amount * COALESCE(
+      i.price,
+      i_b.price
+    ) AS protocol_fee_amount_usd,
+    event_attributes :protocol_fee [0] :denom :: STRING AS protocol_fee_currency
+  FROM
+    event_tx t
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = o.hour
+    AND t.event_attributes :burn_amount [0] :denom :: STRING = o.currency
+    LEFT OUTER JOIN prices i
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = i.hour
+    AND t.event_attributes :protocol_fee [0] :denom :: STRING = i.currency
+    LEFT OUTER JOIN prices_backup o_b
+    ON DATE_TRUNC(
+      'day',
+      t.block_timestamp
+    ) = o_b.day
+    AND t.event_attributes :burn_amount [0] :denom :: STRING = o_b.currency
+    LEFT OUTER JOIN prices_backup i_b
+    ON DATE_TRUNC(
+      'day',
+      t.block_timestamp
+    ) = i_b.day
+    AND t.event_attributes :protocol_fee [0] :denom :: STRING = i_b.currency
+  WHERE
+    event_attributes :burn_amount IS NOT NULL
+)
+SELECT
   blockchain,
   chain_id,
   block_id,
@@ -205,12 +282,11 @@ SELECT
   unlocked_currency,
   contract_address,
   contract_label
-FROM msgs m
-
-JOIN withdraw_events w 
+FROM
+  msgs m
+  JOIN withdraw_events w
   ON m.tx_id = w.tx_id
-
-JOIN burn_events b 
+  JOIN burn_events b
   ON m.tx_id = b.tx_id
-
-WHERE unlocked_amount IS NOT NULL
+WHERE
+  unlocked_amount IS NOT NULL

--- a/models/terra/mirror__gov_staking.sql
+++ b/models/terra/mirror__gov_staking.sql
@@ -1,6 +1,6 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'block_id, tx_id, msg_index ',
+  unique_key = "CONCAT_WS('-',block_id, tx_id, msg_index)",
   incremental_strategy = 'delete+insert',
   cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'mirror', 'mirror_gov']

--- a/models/terra/mirror__gov_staking.sql
+++ b/models/terra/mirror__gov_staking.sql
@@ -1,8 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'block_id || tx_id || msg_index ',
+  unique_key = 'block_id, tx_id, msg_index ',
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp', 'block_id','msg_index'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'mirror', 'mirror_gov']
 ) }}
 

--- a/models/terra/mirror__gov_vote.sql
+++ b/models/terra/mirror__gov_vote.sql
@@ -1,32 +1,43 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'mirror', 'mirror_gov']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'mirror', 'mirror_gov']
 ) }}
 
-SELECT 
+SELECT
   m.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  msg_value:sender::string as voter,
-  msg_value:execute_msg:cast_vote:poll_id::number as poll_id,
-  msg_value:execute_msg:cast_vote:vote::string as vote,
-  msg_value:execute_msg:cast_vote:amount / POW(10,6) as balance,
-  msg_value:contract::string as contract_address,
-  l.address as contract_label 
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-WHERE msg_value:contract::string = 'terra1wh39swv7nq36pnefnupttm2nr96kz7jjddyt2x' -- MIR Governance
-  AND msg_value:execute_msg:cast_vote IS NOT NULL 
+  msg_value :sender :: STRING AS voter,
+  msg_value :execute_msg :cast_vote :poll_id :: NUMBER AS poll_id,
+  msg_value :execute_msg :cast_vote :vote :: STRING AS vote,
+  msg_value :execute_msg :cast_vote :amount / pow(
+    10,
+    6
+  ) AS balance,
+  msg_value :contract :: STRING AS contract_address,
+  l.address AS contract_label
+FROM
+  {{ ref('silver_terra__msgs') }}
+  m
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+  ON msg_value :contract :: STRING = l.address
+WHERE
+  msg_value :contract :: STRING = 'terra1wh39swv7nq36pnefnupttm2nr96kz7jjddyt2x' -- MIR Governance
+  AND msg_value :execute_msg :cast_vote IS NOT NULL
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/mirror__liquidations.sql
+++ b/models/terra/mirror__liquidations.sql
@@ -1,132 +1,188 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'mirror', 'liquidations']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'mirror', 'liquidations']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
-), 
-
-msgs AS (
-
-SELECT 
-  blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:send:msg:auction:position_idx as collateral_id,
-  msg_value:execute_msg:send:contract::string as contract_address
-FROM {{ref('silver_terra__msgs')}}
-WHERE msg_value:execute_msg:send:msg:auction IS NOT NULL 
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-),
-
-events AS (
-
-SELECT 
-  tx_id,
-  COALESCE((event_attributes:"0_tax_amount"[0]:amount + event_attributes:"1_tax_amount"[0]:amount), event_attributes:tax_amount[0]:amount) / POW(10,6) AS tax_amount,
-  COALESCE(event_attributes:"1_tax_amount"[0]:denom::string,event_attributes:tax_amount[0]:denom::string) AS tax_currency,
-  
-  event_attributes:protocol_fee[0]:amount / POW(10,6) as protocol_fee_amount,
-  event_attributes:protocol_fee[0]:denom::string as protocol_fee_currency,
-  
-  event_attributes:liquidated_amount[0]:amount / POW(10,6) as liquidated_amount,
-  event_attributes:liquidated_amount[0]:denom::string as liquidated_currency,
-  
-  event_attributes:return_collateral_amount[0]:amount / POW(10,6) as return_collateral_amount,
-  event_attributes:return_collateral_amount[0]:denom::string as return_collateral_currency,
-  
-  event_attributes:unlocked_amount[0]:amount / POW(10,6) as unlocked_amount,
-  event_attributes:unlocked_amount[0]:denom::string as unlocked_currency,
-  
-  event_attributes:owner::string as owner
-FROM {{ref('silver_terra__msg_events')}}
-WHERE event_type = 'from_contract'
-  AND tx_id IN(SELECT tx_id FROM msgs)
-  AND event_attributes:return_collateral_amount IS NOT NULL
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+msgs AS (
+  SELECT
+    blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value :sender :: STRING AS sender,
+    msg_value :execute_msg :send :msg :auction :position_idx AS collateral_id,
+    msg_value :execute_msg :send :contract :: STRING AS contract_address
+  FROM
+    {{ ref('silver_terra__msgs') }}
+  WHERE
+    msg_value :execute_msg :send :msg :auction IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
-SELECT 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+events AS (
+  SELECT
+    tx_id,
+    COALESCE(
+      (
+        event_attributes :"0_tax_amount" [0] :amount + event_attributes :"1_tax_amount" [0] :amount
+      ),
+      event_attributes :tax_amount [0] :amount
+    ) / pow(
+      10,
+      6
+    ) AS tax_amount,
+    COALESCE(
+      event_attributes :"1_tax_amount" [0] :denom :: STRING,
+      event_attributes :tax_amount [0] :denom :: STRING
+    ) AS tax_currency,
+    event_attributes :protocol_fee [0] :amount / pow(
+      10,
+      6
+    ) AS protocol_fee_amount,
+    event_attributes :protocol_fee [0] :denom :: STRING AS protocol_fee_currency,
+    event_attributes :liquidated_amount [0] :amount / pow(
+      10,
+      6
+    ) AS liquidated_amount,
+    event_attributes :liquidated_amount [0] :denom :: STRING AS liquidated_currency,
+    event_attributes :return_collateral_amount [0] :amount / pow(
+      10,
+      6
+    ) AS return_collateral_amount,
+    event_attributes :return_collateral_amount [0] :denom :: STRING AS return_collateral_currency,
+    event_attributes :unlocked_amount [0] :amount / pow(
+      10,
+      6
+    ) AS unlocked_amount,
+    event_attributes :unlocked_amount [0] :denom :: STRING AS unlocked_currency,
+    event_attributes :owner :: STRING AS owner
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+  WHERE
+    event_type = 'from_contract'
+    AND tx_id IN(
+      SELECT
+        tx_id
+      FROM
+        msgs
+    )
+    AND event_attributes :return_collateral_amount IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
+SELECT
   m.blockchain,
   chain_id,
   block_id,
   block_timestamp,
   m.tx_id,
   collateral_id,
-  sender as buyer,
+  sender AS buyer,
   owner,
   tax_amount,
-  tax_amount * t.price as tax_amount_usd,
+  tax_amount * t.price AS tax_amount_usd,
   tax_currency,
   protocol_fee_amount,
-  protocol_fee_amount * p.price as protocol_fee_amount_usd,
+  protocol_fee_amount * p.price AS protocol_fee_amount_usd,
   protocol_fee_currency,
   liquidated_amount,
-  liquidated_amount * l.price as liquidated_amount_usd,
+  liquidated_amount * l.price AS liquidated_amount_usd,
   liquidated_currency,
   return_collateral_amount,
-  return_collateral_amount * r.price as return_collateral_amount_usd,
+  return_collateral_amount * r.price AS return_collateral_amount_usd,
   return_collateral_currency,
   unlocked_amount,
-  unlocked_amount * u.price as unlocked_amount_usd,
+  unlocked_amount * u.price AS unlocked_amount_usd,
   unlocked_currency,
   contract_address,
   g.address AS contract_label
-FROM msgs m
-
-JOIN events e 
+FROM
+  msgs m
+  JOIN events e
   ON m.tx_id = e.tx_id
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as g
-ON m.contract_address = g.address
-
-LEFT OUTER JOIN prices t
- ON date_trunc('hour', m.block_timestamp) = t.hour
- AND tax_currency = t.currency 
-
-LEFT OUTER JOIN prices p
- ON date_trunc('hour', m.block_timestamp) = p.hour
- AND protocol_fee_currency = p.currency 
-
-LEFT OUTER JOIN prices l
- ON date_trunc('hour', m.block_timestamp) = l.hour
- AND liquidated_currency = l.currency 
-
-LEFT OUTER JOIN prices r
- ON date_trunc('hour', m.block_timestamp) = r.hour
- AND return_collateral_currency = r.currency 
-
-LEFT OUTER JOIN prices u
- ON date_trunc('hour', m.block_timestamp) = u.hour
- AND unlocked_currency = u.currency 
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS g
+  ON m.contract_address = g.address
+  LEFT OUTER JOIN prices t
+  ON DATE_TRUNC(
+    'hour',
+    m.block_timestamp
+  ) = t.hour
+  AND tax_currency = t.currency
+  LEFT OUTER JOIN prices p
+  ON DATE_TRUNC(
+    'hour',
+    m.block_timestamp
+  ) = p.hour
+  AND protocol_fee_currency = p.currency
+  LEFT OUTER JOIN prices l
+  ON DATE_TRUNC(
+    'hour',
+    m.block_timestamp
+  ) = l.hour
+  AND liquidated_currency = l.currency
+  LEFT OUTER JOIN prices r
+  ON DATE_TRUNC(
+    'hour',
+    m.block_timestamp
+  ) = r.hour
+  AND return_collateral_currency = r.currency
+  LEFT OUTER JOIN prices u
+  ON DATE_TRUNC(
+    'hour',
+    m.block_timestamp
+  ) = u.hour
+  AND unlocked_currency = u.currency

--- a/models/terra/mirror__open_collateral.sql
+++ b/models/terra/mirror__open_collateral.sql
@@ -1,89 +1,125 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'mirror', 'collateral']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'mirror', 'collateral']
 ) }}
-
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
-), 
-
-msgs AS(
-
-SELECT
-  m.blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  msg_value:execute_msg:open_position:collateral_ratio as collateral_ratio,
-  msg_value:sender::string as sender,
-  msg_value:contract::string as contract_address,
-  l.address as contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-WHERE msg_value:contract::string = 'terra1wfz7h3aqf4cjmjcvc6s8lxdhh7k30nkczyf0mj' -- Mirror Mint Contract
-  AND msg_value:execute_msg:open_position IS NOT NULL
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-   
-events AS(
-
-SELECT
-  tx_id,
-  event_attributes:position_idx as collateral_id,
-  event_attributes:collateral_amount[0]:amount/ POW(10,6) as collateral_amount,
-  collateral_amount * o.price AS collateral_amount_usd,
-  event_attributes:collateral_amount[0]:denom::string as collateral_currency,
-  event_attributes:mint_amount[0]:amount/ POW(10,6) as mint_amount,
-  mint_amount * i.price AS mint_amount_usd,
-  event_attributes:mint_amount[0]:denom::string as mint_currency
-FROM {{ref('silver_terra__msg_events')}} t
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', t.block_timestamp) = o.hour
- AND t.event_attributes:collateral_amount[0]:denom::string = o.currency 
-
-LEFT OUTER JOIN prices i
- ON date_trunc('hour', t.block_timestamp) = i.hour
- AND t.event_attributes:mint_amount[0]:denom::string = i.currency  
-
-WHERE t.event_attributes:is_short::string = 'false'
-  AND tx_id IN(SELECT DISTINCT tx_id FROM msgs)
-  AND event_type = 'from_contract'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+msgs AS(
+  SELECT
+    m.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value :execute_msg :open_position :collateral_ratio AS collateral_ratio,
+    msg_value :sender :: STRING AS sender,
+    msg_value :contract :: STRING AS contract_address,
+    l.address AS contract_label
+  FROM
+    {{ ref('silver_terra__msgs') }}
+    m
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :contract :: STRING = l.address
+  WHERE
+    msg_value :contract :: STRING = 'terra1wfz7h3aqf4cjmjcvc6s8lxdhh7k30nkczyf0mj' -- Mirror Mint Contract
+    AND msg_value :execute_msg :open_position IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+events AS(
+  SELECT
+    tx_id,
+    event_attributes :position_idx AS collateral_id,
+    event_attributes :collateral_amount [0] :amount / pow(
+      10,
+      6
+    ) AS collateral_amount,
+    collateral_amount * o.price AS collateral_amount_usd,
+    event_attributes :collateral_amount [0] :denom :: STRING AS collateral_currency,
+    event_attributes :mint_amount [0] :amount / pow(
+      10,
+      6
+    ) AS mint_amount,
+    mint_amount * i.price AS mint_amount_usd,
+    event_attributes :mint_amount [0] :denom :: STRING AS mint_currency
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    t
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = o.hour
+    AND t.event_attributes :collateral_amount [0] :denom :: STRING = o.currency
+    LEFT OUTER JOIN prices i
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = i.hour
+    AND t.event_attributes :mint_amount [0] :denom :: STRING = i.currency
+  WHERE
+    t.event_attributes :is_short :: STRING = 'false'
+    AND tx_id IN(
+      SELECT
+        DISTINCT tx_id
+      FROM
+        msgs
+    )
+    AND event_type = 'from_contract'
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
 SELECT
   blockchain,
   chain_id,
@@ -101,7 +137,7 @@ SELECT
   mint_currency,
   contract_address,
   contract_label
-FROM msgs m
-
-JOIN events e 
+FROM
+  msgs m
+  JOIN events e
   ON m.tx_id = e.tx_id

--- a/models/terra/mirror__open_short_farm.sql
+++ b/models/terra/mirror__open_short_farm.sql
@@ -1,141 +1,188 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'mirror', 'short_farm']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'mirror', 'short_farm']
 ) }}
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
 ),
+msgs AS(
+  SELECT
+    m.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value :sender :: STRING AS sender,
+    msg_value :execute_msg :open_position :collateral_ratio AS collateral_ratio,
+    msg_value :contract :: STRING AS contract_address,
+    l.address AS contract_label
+  FROM
+    {{ ref('silver_terra__msgs') }}
+    m
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :contract :: STRING = l.address
+  WHERE
+    msg_value :contract :: STRING = 'terra1wfz7h3aqf4cjmjcvc6s8lxdhh7k30nkczyf0mj' --Mirror Mint
+    AND msg_value :execute_msg :open_position IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
-msgs as(
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+events AS (
+  SELECT
+    tx_id,
+    event_attributes :"0_position_idx" AS collateral_id,
+    event_attributes :collateral_amount [0] :amount / pow(
+      10,
+      6
+    ) AS collateral_amount,
+    collateral_amount * o.price AS collateral_amount_usd,
+    event_attributes :collateral_amount [0] :denom :: STRING AS collateral_currency,
+    event_attributes :mint_amount [0] :amount / pow(
+      10,
+      6
+    ) AS mint_amount,
+    mint_amount * i.price AS mint_amount_usd,
+    event_attributes :mint_amount [0] :denom :: STRING AS mint_currency,
+    event_attributes :return_amount / pow(
+      10,
+      6
+    ) AS return_amount,
+    return_amount * r.price AS return_amount_usd,
+    'uusd' AS return_currency,
+    event_attributes :locked_amount [0] :amount / pow(
+      10,
+      6
+    ) AS locked_amount,
+    locked_amount * l.price AS locked_amount_usd,
+    event_attributes :locked_amount [0] :denom :: STRING AS locked_currency,
+    event_attributes :tax_amount / pow(
+      10,
+      6
+    ) AS tax_amount,
+    event_attributes :commission_amount / pow(
+      10,
+      6
+    ) AS commission_amount,
+    event_attributes :spread_amount / pow(
+      10,
+      6
+    ) AS spread_amount,
+    TO_TIMESTAMP(
+      event_attributes :unlock_time :: numeric
+    ) AS unlock_time
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    t
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = o.hour
+    AND t.event_attributes :collateral_amount [0] :denom :: STRING = o.currency
+    LEFT OUTER JOIN prices i
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = i.hour
+    AND t.event_attributes :mint_amount [0] :denom :: STRING = i.currency
+    LEFT OUTER JOIN prices r
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = r.hour
+    AND 'uusd' = r.currency
+    LEFT OUTER JOIN prices l
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = l.hour
+    AND t.event_attributes :locked_amount [0] :denom :: STRING = l.currency
+  WHERE
+    event_type = 'from_contract'
+    AND event_attributes :is_short :: STRING = 'true'
+    AND event_attributes :from :: STRING = 'terra1wfz7h3aqf4cjmjcvc6s8lxdhh7k30nkczyf0mj' -- Mirror Mint
+    AND tx_status = 'SUCCEEDED'
 
-SELECT 
-  m.blockchain,
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
+SELECT
+  blockchain,
   chain_id,
   block_id,
   block_timestamp,
-  tx_id,
-  msg_value:sender::string AS sender,
-  msg_value:execute_msg:open_position:collateral_ratio AS collateral_ratio,
-  msg_value:contract::string AS contract_address,
-  l.address AS contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-WHERE msg_value:contract::string = 'terra1wfz7h3aqf4cjmjcvc6s8lxdhh7k30nkczyf0mj' --Mirror Mint
-  AND msg_value:execute_msg:open_position IS NOT NULL 
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-
-events as (
-
-SELECT
-  tx_id,
-  event_attributes:"0_position_idx" as collateral_id,
-  
-  event_attributes:collateral_amount[0]:amount / POW(10,6) AS collateral_amount, 
-  collateral_amount * o.price AS collateral_amount_usd,
-  event_attributes:collateral_amount[0]:denom::string AS collateral_currency,
-  
-  event_attributes:mint_amount[0]:amount / POW(10,6) AS mint_amount,
-  mint_amount * i.price AS mint_amount_usd, 
-  event_attributes:mint_amount[0]:denom::string AS mint_currency,
-  
-  event_attributes:return_amount / POW(10,6) AS return_amount,
-  return_amount * r.price AS return_amount_usd, 
-  'uusd' AS return_currency, 
-  
-  event_attributes:locked_amount[0]:amount / POW(10,6) AS locked_amount,
-  locked_amount * l.price AS locked_amount_usd,
-  event_attributes:locked_amount[0]:denom::string AS locked_currency,
-  
-  event_attributes:tax_amount / POW(10,6) AS tax_amount,
-  event_attributes:commission_amount / POW(10,6) AS commission_amount,
-  event_attributes:spread_amount / POW(10,6) AS spread_amount,
-  
-  to_timestamp(event_attributes:unlock_time::numeric) AS unlock_time
-FROM {{ref('silver_terra__msg_events')}} t
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', t.block_timestamp) = o.hour
- AND t.event_attributes:collateral_amount[0]:denom::string = o.currency 
-
-LEFT OUTER JOIN prices i
- ON date_trunc('hour', t.block_timestamp) = i.hour
- AND t.event_attributes:mint_amount[0]:denom::string = i.currency  
-
-LEFT OUTER JOIN prices r
- ON date_trunc('hour', t.block_timestamp) = r.hour
- AND 'uusd' = r.currency 
-
-LEFT OUTER JOIN prices l
- ON date_trunc('hour', t.block_timestamp) = l.hour
- AND t.event_attributes:locked_amount[0]:denom::string = l.currency  
-
-WHERE event_type = 'from_contract'
-  AND event_attributes:is_short::string = 'true'
-  AND event_attributes:from::string = 'terra1wfz7h3aqf4cjmjcvc6s8lxdhh7k30nkczyf0mj' -- Mirror Mint
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-)
-
-SELECT
-  blockchain, 
-  chain_id, 
-  block_id, 
-  block_timestamp, 
-  m.tx_id, 
+  m.tx_id,
   collateral_id,
-  collateral_ratio, 
-  sender, 
+  collateral_ratio,
+  sender,
   tax_amount,
   commission_amount,
   spread_amount,
-  collateral_amount, 
-  collateral_amount_usd, 
-  collateral_currency, 
+  collateral_amount,
+  collateral_amount_usd,
+  collateral_currency,
   mint_amount,
-  mint_amount_usd, 
-  mint_currency, 
+  mint_amount_usd,
+  mint_currency,
   return_amount,
-  return_amount_usd, 
-  return_currency, 
+  return_amount_usd,
+  return_currency,
   locked_amount,
   locked_amount_usd,
   locked_currency,
   unlock_time,
-  contract_address, 
-  contract_label 
-FROM msgs m 
-
-JOIN events e 
+  contract_address,
+  contract_label
+FROM
+  msgs m
+  JOIN events e
   ON m.tx_id = e.tx_id

--- a/models/terra/mirror__reward_claims.sql
+++ b/models/terra/mirror__reward_claims.sql
@@ -1,9 +1,9 @@
 -- depends_on: {{ ref('silver_terra__msgs') }}
 {{ config(
   materialized = 'incremental',
-  unique_key = 'block_id || tx_id',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp', 'block_id'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'mirror', 'reward_claims']
 ) }}
 

--- a/models/terra/silver/silver_terra__blocks.sql
+++ b/models/terra/silver/silver_terra__blocks.sql
@@ -1,8 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'chain_id || block_id',
+  unique_key = "CONCAT_WS('-', chain_id, block_id)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp', 'block_id'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra_silver', 'terra_blocks']
 ) }}
 

--- a/models/terra/silver/silver_terra__daily_balances.sql
+++ b/models/terra/silver/silver_terra__daily_balances.sql
@@ -1,65 +1,110 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'date || address || currency || balance_type',
+  unique_key = "CONCAT_WS('-', date, address, currency, balance_type)",
   incremental_strategy = 'delete+insert',
   cluster_by = ['date'],
   tags = ['snowflake', 'silver_terra', 'silver_terra__daily_balances']
 ) }}
 
-with address_ranges as (
-  select address,
+WITH address_ranges AS (
+
+  SELECT
+    address,
+    currency,
+    balance_type,
+    'terra' AS blockchain,
+    MIN(
+      block_timestamp :: DATE
+    ) AS min_block_date,
+    MAX(
+      CURRENT_TIMESTAMP :: DATE
+    ) AS max_block_date
+  FROM
+    {{ source(
+      'shared',
+      'terra_balances'
+    ) }}
+  GROUP BY
+    1,
+    2,
+    3,
+    4
+),
+cte_my_date AS (
+  SELECT
+    HOUR :: DATE AS DATE
+  FROM
+    {{ source(
+      'shared',
+      'hours'
+    ) }}
+  GROUP BY
+    1
+),
+all_dates AS (
+  SELECT
+    C.date,
+    A.address,
+    A.currency,
+    A.balance_type,
+    A.blockchain
+  FROM
+    cte_my_date C
+    LEFT JOIN address_ranges A
+    ON C.date BETWEEN A.min_block_date
+    AND A.max_block_date
+  WHERE
+    A.address IS NOT NULL
+),
+eth_balances AS (
+  SELECT
+    address,
+    currency,
+    block_timestamp,
+    balance_type,
+    'terra' AS blockchain,
+    balance
+  FROM
+    {{ source(
+      'shared',
+      'terra_balances'
+    ) }}
+    qualify(ROW_NUMBER() over(PARTITION BY address, currency, block_timestamp :: DATE, balance_type, blockchain
+  ORDER BY
+    block_timestamp DESC)) = 1
+),
+balance_tmp AS (
+  SELECT
+    d.date,
+    d.address,
+    d.currency,
+    b.balance,
+    d.balance_type,
+    d.blockchain
+  FROM
+    all_dates d
+    LEFT JOIN eth_balances b
+    ON d.date = b.block_timestamp :: DATE
+    AND d.address = b.address
+    AND d.currency = b.currency
+    AND d.balance_type = b.balance_type
+    AND d.blockchain = b.blockchain
+)
+SELECT
+  DATE,
+  address,
   currency,
   balance_type,
-  'terra' as blockchain,
-  min(block_timestamp::date) as min_block_date,
-  max(current_timestamp::date) as max_block_date
-from {{ source('shared', 'terra_balances') }}
-group by 1,2,3,4
-),
-CTE_MY_DATE AS (
-  SELECT hour::date as date
-  from {{ source('shared', 'hours') }}
-  group by 1
-  ),
-  all_dates as (
-  select c.date,
-  a.address,
-  a.currency,
-  a.balance_type,
-  a.blockchain
-  from cte_my_date c
-  left join address_ranges a on c.date between a.min_block_date and a.max_block_date
-  where a.address is not null
-  ),
-  eth_balances as (
-select address,
-currency,
-block_timestamp,
-balance_type,
-'terra' as blockchain,
-balance
-from {{ source('shared', 'terra_balances') }}
-QUALIFY(row_number() over(partition by address, currency, block_timestamp::date, balance_type, blockchain order by block_timestamp desc)) = 1
-),
-balance_tmp as (
-select d.date,
-d.address,
-d.currency,
-b.balance,
-d.balance_type,
-d.blockchain
-from all_dates d
-left join eth_balances b on d.date = b.block_timestamp::date 
-                        and d.address = b.address
-                        and d.currency = b.currency
-                        and d.balance_type = b.balance_type
-                        and d.blockchain = b.blockchain
-)
-
-select date,
-address,
-currency,
-balance_type,
-blockchain,
-last_value(balance ignore nulls) over(partition by address,currency,balance_type,blockchain order by date asc rows unbounded preceding) as balance
-from balance_tmp
+  blockchain,
+  LAST_VALUE(
+    balance ignore nulls
+  ) over(
+    PARTITION BY address,
+    currency,
+    balance_type,
+    blockchain
+    ORDER BY
+      DATE ASC rows unbounded preceding
+  ) AS balance
+FROM
+  balance_tmp

--- a/models/terra/silver/silver_terra__msg_events.sql
+++ b/models/terra/silver/silver_terra__msg_events.sql
@@ -1,8 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'chain_id || block_id || tx_id || msg_index || event_index || event_type',
+  unique_key = "CONCAT_WS('-', chain_id, block_id, tx_id, msg_index, event_index, event_type)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp', 'block_id', 'tx_id'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra_silver', 'terra_msg_events']
 ) }}
 

--- a/models/terra/silver/silver_terra__msgs.sql
+++ b/models/terra/silver/silver_terra__msgs.sql
@@ -1,8 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'chain_id || block_id || tx_id || msg_index',
+  unique_key = "CONCAT_WS('-', chain_id, block_id, tx_id, msg_index)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp', 'block_id', 'tx_id'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra_silver', 'terra_msgs']
 ) }}
 

--- a/models/terra/silver/silver_terra__transactions.sql
+++ b/models/terra/silver/silver_terra__transactions.sql
@@ -1,8 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'chain_id || block_id || tx_id',
+  unique_key = "CONCAT_WS('-', chain_id, block_id, tx_id)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp', 'block_id'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra_silver', 'terra_transactions']
 ) }}
 

--- a/models/terra/silver/silver_terra__transitions.sql
+++ b/models/terra/silver/silver_terra__transitions.sql
@@ -1,8 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'HASH(chain_id, block_id, transition_type, index, event)',
+  unique_key = "HASH(chain_id, block_id, transition_type, index, event)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp::DATE', 'block_id'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra_silver', 'terra_transitions']
 ) }}
 

--- a/models/terra/terra__airdrop_claims.sql
+++ b/models/terra/terra__airdrop_claims.sql
@@ -1,8 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'block_id || tx_id',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp', 'block_id'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'airdrops', 'claims']
 ) }}
 

--- a/models/terra/terra__blocks.sql
+++ b/models/terra/terra__blocks.sql
@@ -11,9 +11,3 @@ SELECT
   proposer_address
 FROM
   {{ ref('silver_terra__blocks') }}
-  -- WHERE
-  -- {% if is_incremental() %}
-  --   block_timestamp >= getdate() - interval '1 days'
-  -- {% else %}
-  --   block_timestamp >= getdate() - interval '9 months'
-  -- {% endif %}

--- a/models/terra/terra__daily_balances.sql
+++ b/models/terra/terra__daily_balances.sql
@@ -46,6 +46,5 @@ WHERE
   1 = 1
 
 {% if is_incremental() %}
-AND DATE >= getdate() - INTERVAL '3 days' -- {% else %}
---   date >= getdate() - interval '12 months'
+AND DATE >= getdate() - INTERVAL '3 days'
 {% endif %}

--- a/models/terra/terra__daily_balances.sql
+++ b/models/terra/terra__daily_balances.sql
@@ -1,47 +1,51 @@
-{{ 
-  config(
-    materialized='incremental', 
-    sort=['date', 'currency'], 
-    unique_key='date || address', 
-    incremental_strategy='delete+insert',
-    cluster_by=['date', 'address'],
-    tags=['snowflake', 'terra', 'balances']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  sort = ['date', 'currency'],
+  unique_key = "CONCAT_WS('-', date, address)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['date'],
+  tags = ['snowflake', 'terra', 'balances']
+) }}
 
 WITH prices AS (
- SELECT
-   p.symbol,
-   date_trunc('day', block_timestamp) as day,
-   avg(price_usd) as price
- FROM
-   {{ ref('terra__oracle_prices')}} p
- GROUP BY p.symbol, day
+
+  SELECT
+    p.symbol,
+    DATE_TRUNC(
+      'day',
+      block_timestamp
+    ) AS DAY,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+    p
+  GROUP BY
+    p.symbol,
+    DAY
 )
 SELECT
-  date,
+  DATE,
   b.address,
-  address_labels.l1_label as address_label_type,
-  address_labels.l2_label as address_label_subtype,
-  address_labels.project_name as address_label,
-  address_labels.address as address_name,
+  address_labels.l1_label AS address_label_type,
+  address_labels.l2_label AS address_label_subtype,
+  address_labels.project_name AS address_label,
+  address_labels.address AS address_name,
   balance,
-  balance * p.price as balance_usd,
+  balance * p.price AS balance_usd,
   b.balance_type,
   currency
 FROM
-  {{ ref('silver_terra__daily_balances')}} b
-LEFT OUTER JOIN
-  prices p
-ON
-  p.symbol = b.currency
+  {{ ref('silver_terra__daily_balances') }}
+  b
+  LEFT OUTER JOIN prices p
+  ON p.symbol = b.currency
   AND p.day = b.date
-LEFT OUTER JOIN
-  {{ref('silver_crosschain__address_labels')}} as address_labels
-ON b.address = address_labels.address
-WHERE 1=1
-  {% if is_incremental() %}
-    AND date >= getdate() - interval '3 days'
-  -- {% else %}
-  --   date >= getdate() - interval '12 months'
-  {% endif %}
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS address_labels
+  ON b.address = address_labels.address
+WHERE
+  1 = 1
+
+{% if is_incremental() %}
+AND DATE >= getdate() - INTERVAL '3 days' -- {% else %}
+--   date >= getdate() - interval '12 months'
+{% endif %}

--- a/models/terra/terra__gov_submit_proposal.sql
+++ b/models/terra/terra__gov_submit_proposal.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'gov']
 ) }}
 

--- a/models/terra/terra__gov_submit_proposal.sql
+++ b/models/terra/terra__gov_submit_proposal.sql
@@ -106,6 +106,5 @@ WHERE
   AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra__gov_vote.sql
+++ b/models/terra/terra__gov_vote.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'gov']
 ) }}
 
@@ -71,7 +71,7 @@ SELECT
   b.balance AS voting_power
 FROM
   {{ ref('silver_terra__msgs') }} A
-  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels')}} AS voter_labels
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS voter_labels
   ON msg_value :voter = voter_labels.address
   LEFT OUTER JOIN balances b
   ON DATE(

--- a/models/terra/terra__gov_vote.sql
+++ b/models/terra/terra__gov_vote.sql
@@ -31,14 +31,12 @@ WITH balances AS (
         AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---   AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 )
 
 {% if is_incremental() %}
-AND DATE >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND date >= getdate() - interval '9 months'
+AND DATE >= getdate() - INTERVAL '1 days'
 {% endif %}
 )
 SELECT
@@ -86,6 +84,5 @@ WHERE
   AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra__nft_metadata.sql
+++ b/models/terra/terra__nft_metadata.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     sort = 'created_at_timestamp',
-    unique_key = 'contract_address || token_id',
+    unique_key = "CONCAT_WS('-', contract_address, token_id)",
     incremental_strategy = 'delete+insert',
     tags = ['snowflake', 'terra_views', 'terra__nft_metadata', 'terra']
 ) }}

--- a/models/terra/terra__oracle_prices.sql
+++ b/models/terra/terra__oracle_prices.sql
@@ -91,8 +91,7 @@ massets AS(
     AND msg_value :sender = 'terra128968w0r6cche4pmf4xn5358kx2gth6tr3n0qs' -- Make sure we are pulling right events
 
 {% if is_incremental() %}
-AND m.block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---   AND m.block_timestamp >= getdate() - interval '9 months'
+AND m.block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 )
 SELECT

--- a/models/terra/terra__reward.sql
+++ b/models/terra/terra__reward.sql
@@ -1,31 +1,30 @@
-{{ 
-  config(
-    materialized='incremental', 
-    sort='block_timestamp', 
-    unique_key='block_id', 
-    incremental_strategy='delete+insert',
-    cluster_by=['block_timestamp'],
-    tags=['snowflake', 'terra', 'reward']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  sort = 'block_timestamp',
+  unique_key = "block_id",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'reward']
+) }}
 
 WITH withdraw_delegator_rewards AS (
+
   SELECT
     blockchain,
     chain_id,
     tx_status,
     block_id,
     block_timestamp,
-    tx_id, 
+    tx_id,
     msg_index,
     'withdraw_delegator_rewards' AS action,
     event_rewards_amount AS amount,
     event_rewards_currency AS currency,
     validator_address AS validator,
     delegator_address AS delegator
-  FROM {{ ref('terra_dbt__withdraw_delegator_rewards') }}
+  FROM
+    {{ ref('terra_dbt__withdraw_delegator_rewards') }}
 ),
-
 withdraw_validator_commission AS (
   SELECT
     blockchain,
@@ -33,59 +32,76 @@ withdraw_validator_commission AS (
     tx_status,
     block_id,
     block_timestamp,
-    tx_id, 
+    tx_id,
     msg_index,
     'withdraw_validator_commission' AS action,
     amount,
     currency,
     validator_address AS validator,
     delegator_address AS delegator
-  FROM {{ ref('terra_dbt__withdraw_validator_commission') }}
+  FROM
+    {{ ref('terra_dbt__withdraw_validator_commission') }}
 ),
 prices AS (
-    SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price_usd
-    FROM {{ ref('terra__oracle_prices')}} 
-    GROUP BY 1,2,3
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price_usd
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  GROUP BY
+    1,
+    2,
+    3
 )
-
-SELECT 
-    a.blockchain,
-    a.chain_id,
-    a.tx_status,
-    a.block_id,
-    a.block_timestamp,
-    a.tx_id, 
-    a.msg_index,
-    a.action,
-    a.validator AS validator,
-    validator_labels.l1_label as validator_label_type,
-    validator_labels.l2_label as validator_label_subtype,
-    validator_labels.project_name as validator_address_label,
-    validator_labels.address as validator_address_name,
-    a.delegator,
-    delegator_labels.l1_label as delegator_label_type,
-    delegator_labels.l2_label as delegator_label_subtype,
-    delegator_labels.project_name as delegator_address_label,
-    delegator_labels.address as delegator_address_name,
-    a.amount as event_amount,
-    price_usd,
-    a.amount * price_usd as event_amount_usd,
-    p.symbol AS currency
-FROM (
-    SELECT * FROM withdraw_delegator_rewards
-    UNION ALL 
-    SELECT * FROM withdraw_validator_commission
-) a
-LEFT OUTER JOIN prices p
-  ON p.currency = a.currency
-  AND p.hour = date_trunc('hour', a.block_timestamp)
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} delegator_labels
-  ON a.delegator = delegator_labels.address
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} validator_labels
-  ON a.validator = validator_labels.address
+SELECT
+  A.blockchain,
+  A.chain_id,
+  A.tx_status,
+  A.block_id,
+  A.block_timestamp,
+  A.tx_id,
+  A.msg_index,
+  A.action,
+  A.validator AS validator,
+  validator_labels.l1_label AS validator_label_type,
+  validator_labels.l2_label AS validator_label_subtype,
+  validator_labels.project_name AS validator_address_label,
+  validator_labels.address AS validator_address_name,
+  A.delegator,
+  delegator_labels.l1_label AS delegator_label_type,
+  delegator_labels.l2_label AS delegator_label_subtype,
+  delegator_labels.project_name AS delegator_address_label,
+  delegator_labels.address AS delegator_address_name,
+  A.amount AS event_amount,
+  price_usd,
+  A.amount * price_usd AS event_amount_usd,
+  p.symbol AS currency
+FROM
+  (
+    SELECT
+      *
+    FROM
+      withdraw_delegator_rewards
+    UNION ALL
+    SELECT
+      *
+    FROM
+      withdraw_validator_commission
+  ) A
+  LEFT OUTER JOIN prices p
+  ON p.currency = A.currency
+  AND p.hour = DATE_TRUNC(
+    'hour',
+    A.block_timestamp
+  )
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }}
+  delegator_labels
+  ON A.delegator = delegator_labels.address
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }}
+  validator_labels
+  ON A.validator = validator_labels.address

--- a/models/terra/terra__staking.sql
+++ b/models/terra/terra__staking.sql
@@ -1,35 +1,43 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'staking']
 ) }}
 
 WITH prices AS (
+
   SELECT
-    DATE_TRUNC('hour',block_timestamp) AS hour,
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
     currency,
     symbol,
     AVG(price_usd) AS price_usd
   FROM
     {{ ref('terra__oracle_prices') }}
-  
-  WHERE 1=1
+  WHERE
+    1 = 1
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-  GROUP BY
-    1,
-    2,
-    3
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
 ),
-
 delegate AS (
-
   SELECT
     blockchain,
     chain_id,
@@ -37,24 +45,41 @@ delegate AS (
     block_id,
     block_timestamp,
     tx_id,
-	'delegate' AS action,
-    REGEXP_REPLACE(msg_value :delegator_address,'\"','') AS delegator_address,
-    REGEXP_REPLACE(msg_value :validator_address,'\"','') AS validator_address,
+    'delegate' AS action,
+    REGEXP_REPLACE(
+      msg_value :delegator_address,
+      '\"',
+      ''
+    ) AS delegator_address,
+    REGEXP_REPLACE(
+      msg_value :validator_address,
+      '\"',
+      ''
+    ) AS validator_address,
     REGEXP_REPLACE(msg_value :amount :amount / pow(10, 6), '\"', '') AS amount,
-    REGEXP_REPLACE(msg_value :amount :denom,'\"','') AS currency
+    REGEXP_REPLACE(
+      msg_value :amount :denom,
+      '\"',
+      ''
+    ) AS currency
   FROM
-    {{ref('silver_terra__msgs')}}
+    {{ ref('silver_terra__msgs') }}
   WHERE
     msg_module = 'staking'
     AND msg_type = 'staking/MsgDelegate'
     AND tx_status = 'SUCCEEDED'
-    
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
 ),
-
 undelegate AS (
   SELECT
     blockchain,
@@ -63,24 +88,41 @@ undelegate AS (
     block_id,
     block_timestamp,
     tx_id,
-	'undelegate' AS action,
-    REGEXP_REPLACE(msg_value :delegator_address,'\"','') AS delegator_address,
-    REGEXP_REPLACE(msg_value :validator_address,'\"','') AS validator_address,
+    'undelegate' AS action,
+    REGEXP_REPLACE(
+      msg_value :delegator_address,
+      '\"',
+      ''
+    ) AS delegator_address,
+    REGEXP_REPLACE(
+      msg_value :validator_address,
+      '\"',
+      ''
+    ) AS validator_address,
     REGEXP_REPLACE(msg_value :amount :amount / pow(10, 6), '\"', '') AS amount,
-    REGEXP_REPLACE(msg_value :amount :denom,'\"','') AS currency
+    REGEXP_REPLACE(
+      msg_value :amount :denom,
+      '\"',
+      ''
+    ) AS currency
   FROM
-   {{ref('silver_terra__msgs')}}
+    {{ ref('silver_terra__msgs') }}
   WHERE
     msg_module = 'staking'
     AND msg_type = 'staking/MsgUndelegate'
     AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-  
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
 ),
-
 redelegate AS (
   SELECT
     blockchain,
@@ -89,65 +131,89 @@ redelegate AS (
     block_id,
     block_timestamp,
     tx_id,
-	'redelegate' AS action,
-    REGEXP_REPLACE(msg_value :delegator_address,'\"','') AS delegator_address,
-    REGEXP_REPLACE(msg_value :validator_dst_address,'\"','') AS validator_address,
+    'redelegate' AS action,
+    REGEXP_REPLACE(
+      msg_value :delegator_address,
+      '\"',
+      ''
+    ) AS delegator_address,
+    REGEXP_REPLACE(
+      msg_value :validator_dst_address,
+      '\"',
+      ''
+    ) AS validator_address,
     REGEXP_REPLACE(msg_value :amount :amount / pow(10, 6), '\"', '') AS amount,
-    REGEXP_REPLACE(msg_value :amount :denom,'\"','') AS currency
+    REGEXP_REPLACE(
+      msg_value :amount :denom,
+      '\"',
+      ''
+    ) AS currency
   FROM
-    {{ref('silver_terra__msgs')}}
+    {{ ref('silver_terra__msgs') }}
   WHERE
     msg_module = 'staking'
     AND msg_type = 'staking/MsgBeginRedelegate'
     AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-  
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
-
+{% endif %}
+)
 SELECT
-  a.blockchain,
-  a.chain_id,
-  a.tx_status,
-  a.block_id,
-  a.block_timestamp,
-  a.tx_id,
-  a.action,
-  a.delegator_address,
+  A.blockchain,
+  A.chain_id,
+  A.tx_status,
+  A.block_id,
+  A.block_timestamp,
+  A.tx_id,
+  A.action,
+  A.delegator_address,
   delegator_labels.l1_label AS delegator_label_type,
   delegator_labels.l2_label AS delegator_label_subtype,
   delegator_labels.project_name AS delegator_address_label,
   delegator_labels.address AS delegator_address_name,
-  a.validator_address,
+  A.validator_address,
   validator_labels.l1_label AS validator_label_type,
   validator_labels.l2_label AS validator_label_subtype,
   validator_labels.project_name AS validator_address_label,
   validator_labels.address AS validator_address_name,
-  a.amount :: FLOAT AS event_amount,
+  A.amount :: FLOAT AS event_amount,
   price_usd,
-  a.amount * price_usd AS event_amount_usd,
+  A.amount * price_usd AS event_amount_usd,
   p.symbol AS currency
-FROM (
-    
-    SELECT * FROM delegate
-    
-	UNION ALL
-	
-    SELECT * FROM undelegate
-    
-	UNION ALL
-    
-	SELECT * FROM redelegate
-)a
-  
-LEFT OUTER JOIN prices p
-  ON p.currency = a.currency
-  AND p.hour = DATE_TRUNC('hour', a.block_timestamp)
-
-LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} delegator_labels
+FROM
+  (
+    SELECT
+      *
+    FROM
+      delegate
+    UNION ALL
+    SELECT
+      *
+    FROM
+      undelegate
+    UNION ALL
+    SELECT
+      *
+    FROM
+      redelegate
+  ) A
+  LEFT OUTER JOIN prices p
+  ON p.currency = A.currency
+  AND p.hour = DATE_TRUNC(
+    'hour',
+    A.block_timestamp
+  )
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }}
+  delegator_labels
   ON A.delegator_address = delegator_labels.address
-
-LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} validator_labels
-  ON A.validator_address = validator_labels.address 
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }}
+  validator_labels
+  ON A.validator_address = validator_labels.address

--- a/models/terra/terra__swaps.sql
+++ b/models/terra/terra__swaps.sql
@@ -46,8 +46,7 @@ WITH msgs AS(
     AND msg_type = 'market/MsgSwap'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 events_transfer AS(
@@ -103,8 +102,7 @@ events_transfer AS(
     AND msg_type = 'market/MsgSwap'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 fees AS(
@@ -125,8 +123,7 @@ fees AS(
     AND msg_type = 'market/MsgSwap'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 prices AS (
@@ -162,10 +159,6 @@ SELECT
   ) * fe.price_usd AS swap_fee_amount_usd,
   fe.symbol AS swap_fee_currency,
   m.trader,
-  -- trader_labels.l1_label as trader_label_type,
-  -- trader_labels.l2_label as trader_label_subtype,
-  -- trader_labels.project_name as trader_address_label,
-  -- trader_labels.address_name as trader_address_name,
   aa.symbol AS ask_currency,
   m.offer_amount / pow(
     10,
@@ -176,16 +169,6 @@ SELECT
     6
   ) * oo.price_usd AS offer_amount_usd,
   oo.symbol AS offer_currency,
-  -- et."0_sender" as sender,
-  -- sender_labels.l1_label as sender_label_type,
-  -- sender_labels.l2_label as sender_label_subtype,
-  -- sender_labels.project_name as sender_address_label,
-  -- sender_labels.address_name as sender_address_name,
-  -- et."0_recipient" as receiver,
-  -- receiver_labels.l1_label as receiver_label_type,
-  -- receiver_labels.l2_label as receiver_label_subtype,
-  -- receiver_labels.project_name as receiver_address_label,
-  -- receiver_labels.address_name as receiver_address_name,
   et."0_amount" / pow(
     10,
     6
@@ -238,11 +221,6 @@ FROM
     'hour',
     m.block_timestamp
   ) = aa.hour
-  AND m.ask_currency = aa.currency -- LEFT OUTER JOIN {{source('shared','udm_address_labels')}} as trader_labels
-  -- ON m.trader = trader_labels.address
-  -- LEFT OUTER JOIN {{source('shared','udm_address_labels')}} as sender_labels
-  -- ON et."0_sender" = sender_labels.address
-  -- LEFT OUTER JOIN {{source('shared','udm_address_labels')}} as receiver_labels
-  -- ON et."0_recipient" = receiver_labels.address
+  AND m.ask_currency = aa.currency
 WHERE
   tx_status = 'SUCCEEDED'

--- a/models/terra/terra__swaps.sql
+++ b/models/terra/terra__swaps.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'swap']
 ) }}
 

--- a/models/terra/terra__tax_rate.sql
+++ b/models/terra/terra__tax_rate.sql
@@ -1,23 +1,26 @@
-{{ 
-  config(
-    materialized='incremental', 
-    sort='block_timestamp', 
-    unique_key='block_number', 
-    incremental_strategy='delete+insert',
-    cluster_by=['block_timestamp'],
-    tags=['snowflake', 'terra', 'tax_rate']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  sort = 'block_timestamp',
+  unique_key = "CONCAT_WS('-', block_number)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'tax_rate']
+) }}
 
 SELECT
   blockchain,
   block_timestamp,
   block_number,
   tax_rate
-FROM {{source('terra', 'udm_custom_fields_terra_tax_rate')}}
-WHERE 1=1 
+FROM
+  {{ source(
+    'terra',
+    'udm_custom_fields_terra_tax_rate'
+  ) }}
+WHERE
+  1 = 1
+
 {% if is_incremental() %}
-  AND block_timestamp >= getdate() - interval '1 days'
--- {% else %}
+AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
 --   block_timestamp >= getdate() - interval '9 months'
 {% endif %}

--- a/models/terra/terra__tax_rate.sql
+++ b/models/terra/terra__tax_rate.sql
@@ -21,6 +21,5 @@ WHERE
   1 = 1
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---   block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra__transactions.sql
+++ b/models/terra/terra__transactions.sql
@@ -20,9 +20,3 @@ SELECT
   gas_wanted
 FROM
   {{ ref('silver_terra__transactions') }}
-  -- WHERE
-  -- {% if is_incremental() %}
-  --   block_timestamp >= getdate() - interval '1 days'
-  -- {% else %}
-  --   block_timestamp >= getdate() - interval '9 months'
-  -- {% endif %}

--- a/models/terra/terra__transfers.sql
+++ b/models/terra/terra__transfers.sql
@@ -63,8 +63,7 @@ inputs AS(
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---   AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 outputs AS(
@@ -83,8 +82,7 @@ outputs AS(
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---   AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 transfers AS(
@@ -129,8 +127,7 @@ transfers AS(
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 UNION
 SELECT
@@ -155,8 +152,7 @@ WHERE
   AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 )
 SELECT

--- a/models/terra/terra__validator_voting_power.sql
+++ b/models/terra/terra__validator_voting_power.sql
@@ -1,24 +1,27 @@
-{{ 
-  config(
-    materialized='incremental', 
-    sort='block_timestamp', 
-    unique_key='block_id', 
-    incremental_strategy='delete+insert',
-    cluster_by=['block_timestamp'],
-    tags=['snowflake', 'terra', 'voting_power']
-  )
-}}
+{{ config(
+  materialized = 'incremental',
+  sort = 'block_timestamp',
+  unique_key = "block_id",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'voting_power']
+) }}
 
 SELECT
-  block_number AS block_id, 
+  block_number AS block_id,
   block_timestamp,
   blockchain,
   address,
   voting_power
-FROM {{source('terra', 'terra_validator_voting_power')}}
-WHERE 1=1
+FROM
+  {{ source(
+    'terra',
+    'terra_validator_voting_power'
+  ) }}
+WHERE
+  1 = 1
+
 {% if is_incremental() %}
-  AND block_timestamp >= getdate() - interval '1 days'
--- {% else %}
+AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
 --   block_timestamp >= getdate() - interval '9 months'
 {% endif %}

--- a/models/terra/terra__validator_voting_power.sql
+++ b/models/terra/terra__validator_voting_power.sql
@@ -22,6 +22,5 @@ WHERE
   1 = 1
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---   block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__blocks.sql
+++ b/models/terra/terra_dbt__blocks.sql
@@ -1,6 +1,6 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'chain_id || block_id',
+  unique_key = "CONCAT_WS('-', chain_id, block_id)",
   incremental_strategy = 'delete+insert',
   tags = ['snowflake', 'terra_silver', 'terra_blocks']
 ) }}

--- a/models/terra/terra_dbt__create_validator.sql
+++ b/models/terra/terra_dbt__create_validator.sql
@@ -34,8 +34,7 @@ WITH staking_events AS (
     AND msg_type = 'staking/MsgCreateValidator'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 staking AS (
@@ -115,8 +114,7 @@ staking AS (
     AND msg_type = 'staking/MsgCreateValidator'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 event_base AS (

--- a/models/terra/terra_dbt__create_validator.sql
+++ b/models/terra/terra_dbt__create_validator.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'staking']
 ) }}
 

--- a/models/terra/terra_dbt__delegate.sql
+++ b/models/terra/terra_dbt__delegate.sql
@@ -41,8 +41,7 @@ WITH staking AS (
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
--- AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 )
 SELECT

--- a/models/terra/terra_dbt__delegate.sql
+++ b/models/terra/terra_dbt__delegate.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'staking']
 ) }}
 

--- a/models/terra/terra_dbt__delegate_events.sql
+++ b/models/terra/terra_dbt__delegate_events.sql
@@ -46,6 +46,5 @@ WHERE
   AND msg_type = 'staking/MsgDelegate'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__delegate_events.sql
+++ b/models/terra/terra_dbt__delegate_events.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'staking']
 ) }}
 

--- a/models/terra/terra_dbt__delegate_feed_consent.sql
+++ b/models/terra/terra_dbt__delegate_feed_consent.sql
@@ -33,6 +33,5 @@ WHERE
   AND msg_type = 'oracle/MsgDelegateFeedConsent'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__delegate_feed_consent.sql
+++ b/models/terra/terra_dbt__delegate_feed_consent.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'oracles']
 ) }}
 

--- a/models/terra/terra_dbt__edit_validator.sql
+++ b/models/terra/terra_dbt__edit_validator.sql
@@ -62,8 +62,7 @@ WITH staking_events AS (
     AND msg_type = 'staking/MsgEditValidator'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 staking AS (
@@ -119,8 +118,7 @@ staking AS (
     AND chain_id = 'columbus-3'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
--- AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 UNION
 SELECT
@@ -175,8 +173,7 @@ WHERE
   AND chain_id = 'columbus-4'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 event_base AS (

--- a/models/terra/terra_dbt__edit_validator.sql
+++ b/models/terra/terra_dbt__edit_validator.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'staking']
 ) }}
 

--- a/models/terra/terra_dbt__gov_deposit.sql
+++ b/models/terra/terra_dbt__gov_deposit.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'gov']
 ) }}
 

--- a/models/terra/terra_dbt__gov_deposit.sql
+++ b/models/terra/terra_dbt__gov_deposit.sql
@@ -38,6 +38,5 @@ WHERE
   AND msg_type = 'gov/MsgDeposit'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__grant_authorization.sql
+++ b/models/terra/terra_dbt__grant_authorization.sql
@@ -52,6 +52,5 @@ WHERE
   AND msg_type = 'msgauth/MsgGrantAuthorization'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__grant_authorization.sql
+++ b/models/terra/terra_dbt__grant_authorization.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'grant']
 ) }}
 

--- a/models/terra/terra_dbt__grant_exec_authorized.sql
+++ b/models/terra/terra_dbt__grant_exec_authorized.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'grant']
 ) }}
 

--- a/models/terra/terra_dbt__grant_exec_authorized.sql
+++ b/models/terra/terra_dbt__grant_exec_authorized.sql
@@ -52,6 +52,5 @@ WHERE
   AND msg_type = 'msgauth/MsgExecAuthorized'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__modify_withdraw_address.sql
+++ b/models/terra/terra_dbt__modify_withdraw_address.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'reward']
 ) }}
 

--- a/models/terra/terra_dbt__modify_withdraw_address.sql
+++ b/models/terra/terra_dbt__modify_withdraw_address.sql
@@ -33,8 +33,7 @@ WITH rewards_event AS (
     AND msg_type = 'distribution/MsgModifyWithdrawAddress'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 rewards AS (
@@ -63,8 +62,7 @@ rewards AS (
     AND msg_type = 'distribution/MsgModifyWithdrawAddress'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 rewards_event_base AS (

--- a/models/terra/terra_dbt__msg_events.sql
+++ b/models/terra/terra_dbt__msg_events.sql
@@ -1,7 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'chain_id || block_id || tx_id || msg_index || event_index',
+  unique_key = "CONCAT_WS('-', chain_id, block_id, tx_id, msg_index, event_index)",
   incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra_silver', 'terra_msg_events']
 ) }}
 

--- a/models/terra/terra_dbt__msg_events_bank_transfer_events.sql
+++ b/models/terra/terra_dbt__msg_events_bank_transfer_events.sql
@@ -42,8 +42,7 @@ WITH input AS (
     AND event_type = 'transfer'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 tbl_recipient AS (
@@ -67,8 +66,7 @@ tbl_recipient AS (
     message_attribute = 'recipient'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 tbl_amount AS (

--- a/models/terra/terra_dbt__msg_events_bank_transfer_events.sql
+++ b/models/terra/terra_dbt__msg_events_bank_transfer_events.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'transfer']
 ) }}
 

--- a/models/terra/terra_dbt__msg_events_cosmos_message.sql
+++ b/models/terra/terra_dbt__msg_events_cosmos_message.sql
@@ -29,6 +29,5 @@ WHERE
   AND event_type = 'message'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__msg_events_cosmos_message.sql
+++ b/models/terra/terra_dbt__msg_events_cosmos_message.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'cosmos']
 ) }}
 

--- a/models/terra/terra_dbt__msg_events_gov_proposal_vote_events.sql
+++ b/models/terra/terra_dbt__msg_events_gov_proposal_vote_events.sql
@@ -29,6 +29,5 @@ WHERE
   AND event_type = 'proposal_vote'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__msg_events_gov_proposal_vote_events.sql
+++ b/models/terra/terra_dbt__msg_events_gov_proposal_vote_events.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'gov']
 ) }}
 

--- a/models/terra/terra_dbt__msg_events_market_swap.sql
+++ b/models/terra/terra_dbt__msg_events_market_swap.sql
@@ -30,6 +30,5 @@ WHERE
   AND event_type = 'swap'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__msg_events_market_swap.sql
+++ b/models/terra/terra_dbt__msg_events_market_swap.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'swap']
 ) }}
 

--- a/models/terra/terra_dbt__msg_events_msgauth_grant_events.sql
+++ b/models/terra/terra_dbt__msg_events_msgauth_grant_events.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'grant']
 ) }}
 

--- a/models/terra/terra_dbt__msg_events_msgauth_grant_events.sql
+++ b/models/terra/terra_dbt__msg_events_msgauth_grant_events.sql
@@ -29,6 +29,5 @@ WHERE
   AND event_type = 'grant_authorization'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__msg_events_oracle_events.sql
+++ b/models/terra/terra_dbt__msg_events_oracle_events.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'oracles']
 ) }}
 

--- a/models/terra/terra_dbt__msg_events_oracle_events.sql
+++ b/models/terra/terra_dbt__msg_events_oracle_events.sql
@@ -29,6 +29,5 @@ WHERE
   AND event_type = 'vote'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__msgs.sql
+++ b/models/terra/terra_dbt__msgs.sql
@@ -1,6 +1,6 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'chain_id || block_id || tx_id || msg_index',
+  unique_key = "CONCAT_WS('-', chain_id, block_id, tx_id, msg_index)",
   incremental_strategy = 'delete+insert',
   tags = ['snowflake', 'terra_silver', 'terra_msgs']
 ) }}

--- a/models/terra/terra_dbt__nft_metadata_galactic_punks.sql
+++ b/models/terra/terra_dbt__nft_metadata_galactic_punks.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'contract_address || token_id',
+    unique_key = "CONCAT_WS('-', contract_address, token_id)",
     incremental_strategy = 'delete+insert',
     tags = ['snowflake', 'terra_silver', 'terra_dbt__nft_metadata']
 ) }}

--- a/models/terra/terra_dbt__oracle_events.sql
+++ b/models/terra/terra_dbt__oracle_events.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'oracles']
 ) }}
 

--- a/models/terra/terra_dbt__oracle_events.sql
+++ b/models/terra/terra_dbt__oracle_events.sql
@@ -46,8 +46,7 @@ WHERE
   AND msg_type = 'oracle/MsgAggregateExchangeRateVote'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 UNION
 SELECT
@@ -86,6 +85,5 @@ WHERE
   AND msg_type = 'oracle/MsgExchangeRateVote'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__redelegate.sql
+++ b/models/terra/terra_dbt__redelegate.sql
@@ -46,8 +46,7 @@ WITH staking AS (
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 )
 SELECT

--- a/models/terra/terra_dbt__redelegate.sql
+++ b/models/terra/terra_dbt__redelegate.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'staking']
 ) }}
 

--- a/models/terra/terra_dbt__staking.sql
+++ b/models/terra/terra_dbt__staking.sql
@@ -30,8 +30,7 @@ WITH staking_msg_events AS (
     AND event_type = 'delegate'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 staking_msg AS (
@@ -70,8 +69,7 @@ staking_msg AS (
     AND msg_type = 'staking/MsgDelegate'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 )
 SELECT

--- a/models/terra/terra_dbt__staking.sql
+++ b/models/terra/terra_dbt__staking.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'staking']
 ) }}
 

--- a/models/terra/terra_dbt__transactions.sql
+++ b/models/terra/terra_dbt__transactions.sql
@@ -1,6 +1,6 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'chain_id || block_id || tx_id',
+  unique_key = "CONCAT_WS('-', chain_id, block_id, tx_id)",
   incremental_strategy = 'delete+insert',
   tags = ['snowflake', 'terra_silver', 'terra_transactions']
 ) }}

--- a/models/terra/terra_dbt__transitions.sql
+++ b/models/terra/terra_dbt__transitions.sql
@@ -1,8 +1,8 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = 'HASH(chain_id, block_id, transition_type, index, event)',
+  unique_key = "CONCAT_WS('-', chain_id, block_id, transition_type, index, event)",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp::DATE', 'block_id'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra_silver', 'terra_transitions']
 ) }}
 

--- a/models/terra/terra_dbt__undelegate.sql
+++ b/models/terra/terra_dbt__undelegate.sql
@@ -41,8 +41,7 @@ WITH staking AS (
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
--- AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 )
 SELECT

--- a/models/terra/terra_dbt__undelegate.sql
+++ b/models/terra/terra_dbt__undelegate.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'staking']
 ) }}
 

--- a/models/terra/terra_dbt__unjail.sql
+++ b/models/terra/terra_dbt__unjail.sql
@@ -26,6 +26,5 @@ WHERE
   msg_module = 'cosmos'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
---  AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}

--- a/models/terra/terra_dbt__unjail.sql
+++ b/models/terra/terra_dbt__unjail.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'unjail']
 ) }}
 

--- a/models/terra/terra_dbt__withdraw_delegator_rewards.sql
+++ b/models/terra/terra_dbt__withdraw_delegator_rewards.sql
@@ -40,8 +40,7 @@ WITH rewards_event AS (
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
--- AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 rewards AS (
@@ -78,8 +77,7 @@ rewards AS (
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
--- AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 rewards_event_base AS (

--- a/models/terra/terra_dbt__withdraw_delegator_rewards.sql
+++ b/models/terra/terra_dbt__withdraw_delegator_rewards.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'reward']
 ) }}
 

--- a/models/terra/terra_dbt__withdraw_validator_commission.sql
+++ b/models/terra/terra_dbt__withdraw_validator_commission.sql
@@ -40,8 +40,7 @@ WITH rewards_event AS (
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
--- AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 rewards AS (
@@ -78,8 +77,7 @@ rewards AS (
     AND tx_status = 'SUCCEEDED'
 
 {% if is_incremental() %}
-AND block_timestamp >= getdate() - INTERVAL '1 days' -- {% else %}
--- AND block_timestamp >= getdate() - interval '9 months'
+AND block_timestamp >= getdate() - INTERVAL '1 days'
 {% endif %}
 ),
 rewards_event_base AS (

--- a/models/terra/terra_dbt__withdraw_validator_commission.sql
+++ b/models/terra/terra_dbt__withdraw_validator_commission.sql
@@ -1,9 +1,9 @@
 {{ config(
   materialized = 'incremental',
   sort = 'block_timestamp',
-  unique_key = 'block_id',
+  unique_key = "block_id",
   incremental_strategy = 'delete+insert',
-  cluster_by = ['block_timestamp'],
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'terra', 'reward']
 ) }}
 

--- a/models/terra/terraswap__lp_actions.sql
+++ b/models/terra/terraswap__lp_actions.sql
@@ -1,167 +1,227 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'terraswap', 'terraswap_lp_actions']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'terraswap', 'terraswap_lp_actions']
 ) }}
 
-WITH prices as (
+WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
-),
-
-provide_msgs AS (
-
-SELECT
-  m.blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  'provide_liquidity' as event_type,
-  msg_value:sender::string as sender,
-  msg_value:contract::string as pool_address,
-  l.address AS pool_name
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:contract::string = l.address
-
-WHERE msg_value:execute_msg:provide_liquidity IS NOT NULL 
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-
-provide_events AS (
-SELECT
-  tx_id,
-  
-  event_attributes:assets[0]:amount / POW(10,6) AS token_0_amount,
-  token_0_amount * o.price AS token_0_amount_usd,
-  event_attributes:assets[0]:denom::string AS token_0_currency,
-  
-  event_attributes:assets[1]:amount / POW(10,6) AS token_1_amount,
-  token_1_amount * i.price AS token_1_amount_usd,
-  event_attributes:assets[1]:denom::string AS token_1_currency,
-  
-  event_attributes:share / POW(10,6) AS lp_share_amount,
-  CASE 
-    WHEN event_attributes:"2_contract_address"::string = 'terra17yap3mhph35pcwvhza38c2lkj7gzywzy05h7l0' THEN event_attributes:"4_contract_address"::string 
-    ELSE event_attributes:"2_contract_address"::string 
-  END AS lp_pool_address,
-  l.address AS lp_pool_name
-FROM {{ref('silver_terra__msg_events')}} t
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON event_attributes:"2_contract_address"::string = l.address
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as r
-ON event_attributes:"4_contract_address"::string = r.address
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', t.block_timestamp) = o.hour
- AND t.event_attributes:assets[0]:denom::string = o.currency 
-
-LEFT OUTER JOIN prices i
- ON date_trunc('hour', t.block_timestamp) = i.hour
- AND t.event_attributes:assets[1]:denom::string = i.currency  
-
-WHERE event_attributes:assets IS NOT NULL
-  AND tx_id IN(SELECT DISTINCT tx_id FROM provide_msgs)
-  AND event_type = 'from_contract'
-
-  {% if is_incremental() %}
-    AND t.block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-
-withdraw_msgs AS (
-  
-SELECT
-  m.blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  'withdraw_liquidity' as event_type,
-  msg_value:sender::string as sender,
-  msg_value:contract::string as lp_pool_address,
-  l.address AS lp_pool_name,
-  msg_value:execute_msg:send:contract::string as pool_address,
-  p.address AS pool_name
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as p
-ON msg_value:contract::string = p.address
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} as l
-ON msg_value:execute_msg:send:contract::string = l.address
-
-WHERE msg_value:execute_msg:send:msg:withdraw_liquidity IS NOT NULL
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND m.block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-  
-),
-
-withdraw_events AS (
-
-SELECT 
-  tx_id,
-  
-  event_attributes:refund_assets[0]:amount / POW(10,6) AS token_0_amount,
-  token_0_amount * o.price AS token_0_amount_usd,
-  event_attributes:refund_assets[0]:denom::string AS token_0_currency,
-  
-  event_attributes:refund_assets[1]:amount / POW(10,6) AS token_1_amount,
-  token_1_amount * i.price AS token_1_amount_usd,
-  event_attributes:refund_assets[1]:denom::string AS token_1_currency,
-  
-  event_attributes:withdrawn_share / POW(10,6) as lp_share_amount
-FROM {{ref('silver_terra__msg_events')}} t
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', t.block_timestamp) = o.hour
- AND t.event_attributes:refund_assets[0]:denom::string = o.currency 
-
-LEFT OUTER JOIN prices i
- ON date_trunc('hour', t.block_timestamp) = i.hour
- AND t.event_attributes:refund_assets[1]:denom::string = i.currency  
-
-WHERE tx_id IN(SELECT tx_id FROM withdraw_msgs)
-  AND event_type = 'from_contract'
-  AND event_attributes:refund_assets IS NOT NULL 
-
-  {% if is_incremental() %}
-    AND t.block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+provide_msgs AS (
+  SELECT
+    m.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    'provide_liquidity' AS event_type,
+    msg_value :sender :: STRING AS sender,
+    msg_value :contract :: STRING AS pool_address,
+    l.address AS pool_name
+  FROM
+    {{ ref('silver_terra__msgs') }}
+    m
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :contract :: STRING = l.address
+  WHERE
+    msg_value :execute_msg :provide_liquidity IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
--- Provide Liquidity 
-SELECT 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+provide_events AS (
+  SELECT
+    tx_id,
+    event_attributes :assets [0] :amount / pow(
+      10,
+      6
+    ) AS token_0_amount,
+    token_0_amount * o.price AS token_0_amount_usd,
+    event_attributes :assets [0] :denom :: STRING AS token_0_currency,
+    event_attributes :assets [1] :amount / pow(
+      10,
+      6
+    ) AS token_1_amount,
+    token_1_amount * i.price AS token_1_amount_usd,
+    event_attributes :assets [1] :denom :: STRING AS token_1_currency,
+    event_attributes :share / pow(
+      10,
+      6
+    ) AS lp_share_amount,
+    CASE
+      WHEN event_attributes :"2_contract_address" :: STRING = 'terra17yap3mhph35pcwvhza38c2lkj7gzywzy05h7l0' THEN event_attributes :"4_contract_address" :: STRING
+      ELSE event_attributes :"2_contract_address" :: STRING
+    END AS lp_pool_address,
+    l.address AS lp_pool_name
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    t
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON event_attributes :"2_contract_address" :: STRING = l.address
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS r
+    ON event_attributes :"4_contract_address" :: STRING = r.address
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = o.hour
+    AND t.event_attributes :assets [0] :denom :: STRING = o.currency
+    LEFT OUTER JOIN prices i
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = i.hour
+    AND t.event_attributes :assets [1] :denom :: STRING = i.currency
+  WHERE
+    event_attributes :assets IS NOT NULL
+    AND tx_id IN(
+      SELECT
+        DISTINCT tx_id
+      FROM
+        provide_msgs
+    )
+    AND event_type = 'from_contract'
+
+{% if is_incremental() %}
+AND t.block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+withdraw_msgs AS (
+  SELECT
+    m.blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    'withdraw_liquidity' AS event_type,
+    msg_value :sender :: STRING AS sender,
+    msg_value :contract :: STRING AS lp_pool_address,
+    l.address AS lp_pool_name,
+    msg_value :execute_msg :send :contract :: STRING AS pool_address,
+    p.address AS pool_name
+  FROM
+    {{ ref('silver_terra__msgs') }}
+    m
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS p
+    ON msg_value :contract :: STRING = p.address
+    LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }} AS l
+    ON msg_value :execute_msg :send :contract :: STRING = l.address
+  WHERE
+    msg_value :execute_msg :send :msg :withdraw_liquidity IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
+
+{% if is_incremental() %}
+AND m.block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+withdraw_events AS (
+  SELECT
+    tx_id,
+    event_attributes :refund_assets [0] :amount / pow(
+      10,
+      6
+    ) AS token_0_amount,
+    token_0_amount * o.price AS token_0_amount_usd,
+    event_attributes :refund_assets [0] :denom :: STRING AS token_0_currency,
+    event_attributes :refund_assets [1] :amount / pow(
+      10,
+      6
+    ) AS token_1_amount,
+    token_1_amount * i.price AS token_1_amount_usd,
+    event_attributes :refund_assets [1] :denom :: STRING AS token_1_currency,
+    event_attributes :withdrawn_share / pow(
+      10,
+      6
+    ) AS lp_share_amount
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+    t
+    LEFT OUTER JOIN prices o
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = o.hour
+    AND t.event_attributes :refund_assets [0] :denom :: STRING = o.currency
+    LEFT OUTER JOIN prices i
+    ON DATE_TRUNC(
+      'hour',
+      t.block_timestamp
+    ) = i.hour
+    AND t.event_attributes :refund_assets [1] :denom :: STRING = i.currency
+  WHERE
+    tx_id IN(
+      SELECT
+        tx_id
+      FROM
+        withdraw_msgs
+    )
+    AND event_type = 'from_contract'
+    AND event_attributes :refund_assets IS NOT NULL
+
+{% if is_incremental() %}
+AND t.block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+) -- Provide Liquidity
+SELECT
   blockchain,
   chain_id,
   block_id,
@@ -180,15 +240,13 @@ SELECT
   lp_share_amount,
   lp_pool_address,
   lp_pool_name
-FROM provide_msgs m 
-
-JOIN provide_events e 
+FROM
+  provide_msgs m
+  JOIN provide_events e
   ON m.tx_id = e.tx_id
-
-UNION 
-
--- Remove Liquidity 
-SELECT 
+UNION
+  -- Remove Liquidity
+SELECT
   blockchain,
   chain_id,
   block_id,
@@ -207,7 +265,7 @@ SELECT
   lp_share_amount,
   lp_pool_address,
   lp_pool_name
-FROM withdraw_msgs w
-
-JOIN withdraw_events we 
+FROM
+  withdraw_msgs w
+  JOIN withdraw_events we
   ON w.tx_id = we.tx_id

--- a/models/terra/terraswap__lp_stake.sql
+++ b/models/terra/terraswap__lp_stake.sql
@@ -1,53 +1,72 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'terraswap', 'lp']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'terraswap', 'lp']
 ) }}
-
 -- LP Un-staking
 WITH msgs AS (
 
-SELECT 
-  blockchain,
-  chain_id,  
-  block_id,
-  block_timestamp,
-  tx_id,
-  'unstake_lp' as event_type,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:unbond:amount / POW(10,6) as amount
-FROM {{ref('silver_terra__msgs')}}
-WHERE msg_value:execute_msg:unbond IS NOT NULL 
-  AND tx_status = 'SUCCEEDED'
+  SELECT
+    blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    'unstake_lp' AS event_type,
+    msg_value :sender :: STRING AS sender,
+    msg_value :execute_msg :unbond :amount / pow(
+      10,
+      6
+    ) AS amount
+  FROM
+    {{ ref('silver_terra__msgs') }}
+  WHERE
+    msg_value :execute_msg :unbond IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
-),
-
-events AS (
-
-SELECT 
-  tx_id,
-  event_attributes:"0_contract_address"::string as contract_address
-FROM {{ref('silver_terra__msg_events')}}
-where tx_id IN(SELECT distinct tx_id from msgs)
-  AND event_type = 'execute_contract'
-  AND msg_index = 0
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+),
+events AS (
+  SELECT
+    tx_id,
+    event_attributes :"0_contract_address" :: STRING AS contract_address
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+  WHERE
+    tx_id IN(
+      SELECT
+        DISTINCT tx_id
+      FROM
+        msgs
+    )
+    AND event_type = 'execute_contract'
+    AND msg_index = 0
 
--- unstake
-SELECT 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+) -- unstake
+SELECT
   m.blockchain,
-  chain_id,  
+  chain_id,
   block_id,
   block_timestamp,
   m.tx_id,
@@ -55,37 +74,45 @@ SELECT
   sender,
   amount,
   contract_address,
-  address as contract_label
-FROM msgs m
-
-JOIN events e 
+  address AS contract_label
+FROM
+  msgs m
+  JOIN events e
   ON m.tx_id = e.tx_id
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}}
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }}
   ON contract_address = address
-
 UNION
-
--- stake 
-SELECT 
+  -- stake
+SELECT
   m.blockchain,
-  chain_id,  
+  chain_id,
   block_id,
   block_timestamp,
   tx_id,
-  'stake_lp' as event_type,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:send:amount / POW(10,6) as amount,
-  msg_value:contract::string as contract_address,
-  address as contract_label
-FROM {{ref('silver_terra__msgs')}} m
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} 
-  ON msg_value:contract::string = address
-
-WHERE msg_value:execute_msg:send:msg:bond IS NOT NULL 
+  'stake_lp' AS event_type,
+  msg_value :sender :: STRING AS sender,
+  msg_value :execute_msg :send :amount / pow(
+    10,
+    6
+  ) AS amount,
+  msg_value :contract :: STRING AS contract_address,
+  address AS contract_label
+FROM
+  {{ ref('silver_terra__msgs') }}
+  m
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }}
+  ON msg_value :contract :: STRING = address
+WHERE
+  msg_value :execute_msg :send :msg :bond IS NOT NULL
   AND tx_status = 'SUCCEEDED'
 
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}

--- a/models/terra/terraswap__swaps.sql
+++ b/models/terra/terraswap__swaps.sql
@@ -1,94 +1,141 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'block_id || tx_id',
-    incremental_strategy = 'delete+insert',
-    cluster_by = ['block_timestamp', 'block_id'],
-    tags=['snowflake', 'terra', 'terraswap', 'swap']
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'terra', 'terraswap', 'swap']
 ) }}
-
 
 WITH prices AS (
 
-  SELECT 
-      date_trunc('hour', block_timestamp) as hour,
-      currency,
-      symbol,
-      avg(price_usd) as price
-    FROM {{ ref('terra__oracle_prices')}} 
-    
-    WHERE 1=1
-    
-    {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-    {% endif %}
+  SELECT
+    DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) AS HOUR,
+    currency,
+    symbol,
+    AVG(price_usd) AS price
+  FROM
+    {{ ref('terra__oracle_prices') }}
+  WHERE
+    1 = 1
 
-    GROUP BY 1,2,3
-
-),
-
-msgs as (
--- native to non-native/native
-SELECT
-  blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  msg_value:sender::string as sender,
-  msg_value:contract::string as pool_address
-FROM {{ref('silver_terra__msgs')}}
-WHERE msg_value:execute_msg:swap IS NOT NULL
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-  
-
- UNION 
- 
--- non-native to native
-SELECT
-  blockchain,
-  chain_id,
-  block_id,
-  block_timestamp,
-  tx_id,
-  msg_value:sender::string as sender,
-  msg_value:execute_msg:send:contract::string as pool_address
-FROM {{ref('silver_terra__msgs')}}
-
-WHERE msg_value:execute_msg:send:msg:swap IS NOT NULL
-  AND tx_status = 'SUCCEEDED'
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
-),
-
-events as (
-SELECT
-  tx_id,
-  as_number(event_attributes:tax_amount) / POW(10,6) as tax_amount,
-  event_attributes:commission_amount::numeric / POW(10,6) as commission_amount,
-  event_attributes:offer_amount::numeric / POW(10,6) as offer_amount,
-  event_attributes:offer_asset::string as offer_currency,
-  event_attributes:return_amount::numeric / POW(10,6) as return_amount,
-  event_attributes:ask_asset::string as return_currency
-FROM {{ref('silver_terra__msg_events')}}
-
-WHERE event_type = 'from_contract'
-  AND tx_id IN(SELECT DISTINCT tx_id 
- 	  		    FROM msgs )
-  AND event_attributes:offer_amount IS NOT NULL
-
-  {% if is_incremental() %}
-    AND block_timestamp::date >= (select max(block_timestamp::date) from {{ref('silver_terra__msgs')}})
-  {% endif %}
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
 )
+{% endif %}
+GROUP BY
+  1,
+  2,
+  3
+),
+msgs AS (
+  -- native to non-native/native
+  SELECT
+    blockchain,
+    chain_id,
+    block_id,
+    block_timestamp,
+    tx_id,
+    msg_value :sender :: STRING AS sender,
+    msg_value :contract :: STRING AS pool_address
+  FROM
+    {{ ref('silver_terra__msgs') }}
+  WHERE
+    msg_value :execute_msg :swap IS NOT NULL
+    AND tx_status = 'SUCCEEDED'
 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+UNION
+  -- non-native to native
+SELECT
+  blockchain,
+  chain_id,
+  block_id,
+  block_timestamp,
+  tx_id,
+  msg_value :sender :: STRING AS sender,
+  msg_value :execute_msg :send :contract :: STRING AS pool_address
+FROM
+  {{ ref('silver_terra__msgs') }}
+WHERE
+  msg_value :execute_msg :send :msg :swap IS NOT NULL
+  AND tx_status = 'SUCCEEDED'
 
-SELECT 
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+),
+events AS (
+  SELECT
+    tx_id,
+    AS_NUMBER(
+      event_attributes :tax_amount
+    ) / pow(
+      10,
+      6
+    ) AS tax_amount,
+    event_attributes :commission_amount :: numeric / pow(
+      10,
+      6
+    ) AS commission_amount,
+    event_attributes :offer_amount :: numeric / pow(
+      10,
+      6
+    ) AS offer_amount,
+    event_attributes :offer_asset :: STRING AS offer_currency,
+    event_attributes :return_amount :: numeric / pow(
+      10,
+      6
+    ) AS return_amount,
+    event_attributes :ask_asset :: STRING AS return_currency
+  FROM
+    {{ ref('silver_terra__msg_events') }}
+  WHERE
+    event_type = 'from_contract'
+    AND tx_id IN(
+      SELECT
+        DISTINCT tx_id
+      FROM
+        msgs
+    )
+    AND event_attributes :offer_amount IS NOT NULL
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    MAX(
+      block_timestamp :: DATE
+    )
+  FROM
+    {{ ref('silver_terra__msgs') }}
+)
+{% endif %}
+)
+SELECT
   m.blockchain,
   chain_id,
   block_id,
@@ -105,18 +152,22 @@ SELECT
   return_currency,
   pool_address,
   l.address AS pool_name
-FROM msgs m 
-
-JOIN events e 
+FROM
+  msgs m
+  JOIN events e
   ON m.tx_id = e.tx_id
-
-LEFT OUTER JOIN prices o
- ON date_trunc('hour', m.block_timestamp) = o.hour
- AND e.offer_currency = o.currency 
-
-LEFT OUTER JOIN prices r
- ON date_trunc('hour', m.block_timestamp) = r.hour
- AND e.return_currency = r.currency  
-
-LEFT OUTER JOIN {{ref('silver_crosschain__address_labels')}} l
+  LEFT OUTER JOIN prices o
+  ON DATE_TRUNC(
+    'hour',
+    m.block_timestamp
+  ) = o.hour
+  AND e.offer_currency = o.currency
+  LEFT OUTER JOIN prices r
+  ON DATE_TRUNC(
+    'hour',
+    m.block_timestamp
+  ) = r.hour
+  AND e.return_currency = r.currency
+  LEFT OUTER JOIN {{ ref('silver_crosschain__address_labels') }}
+  l
   ON pool_address = address


### PR DESCRIPTION
Changes
- optimize clustering to DATE instead of timestamp
- change unique_key to avoid collisions and unintended data mutation
- remove commented code