### PR TITLE
Update terra views to be secure views.

### DIFF
--- a/models/terra/gold/terra__blocks.sql
+++ b/models/terra/gold/terra__blocks.sql
@@ -1,5 +1,6 @@
 {{ config(
   materialized = 'view',
+  secure = 'true',
   tags = ['snowflake', 'terra_views', 'blocks', 'terra'],
 ) }}
 

--- a/models/terra/gold/terra__labels.sql
+++ b/models/terra/gold/terra__labels.sql
@@ -1,5 +1,6 @@
 {{ config(
       materialized='view',
+      secure = 'true',
       tags=['snowflake', 'terra_views', 'labels', 'terra_labels']  
     ) 
 }}

--- a/models/terra/gold/terra__msg_events.sql
+++ b/models/terra/gold/terra__msg_events.sql
@@ -1,5 +1,6 @@
 {{ config(
   materialized = 'view',
+  secure = 'true',
   tags = ['snowflake', 'terra_views', 'msg_events', 'terra']
 ) }}
 

--- a/models/terra/gold/terra__msgs.sql
+++ b/models/terra/gold/terra__msgs.sql
@@ -1,5 +1,6 @@
 {{ config(
   materialized = 'view',
+  secure = 'true',
   tags = ['snowflake', 'terra_views', 'msgs', 'terra']
 ) }}
 

--- a/models/terra/gold/terra__transactions.sql
+++ b/models/terra/gold/terra__transactions.sql
@@ -1,5 +1,6 @@
 {{ config(
   materialized = 'view',
+  secure = 'true',
   tags = ['snowflake', 'terra_views', 'transactions', 'terra']
 ) }}
 

--- a/models/terra/gold/terra__transitions.sql
+++ b/models/terra/gold/terra__transitions.sql
@@ -1,5 +1,6 @@
 {{ config(
   materialized = 'view',
+  secure = 'true',
   tags = ['snowflake', 'terra_views', 'transitions', 'terra']
 ) }}
 


### PR DESCRIPTION
We're currently running a series of product experiments with community members that would give them access to their own isolated snowflake account, what is known as an external account.

In order to share data into an external account, we create "SHARES". A "SHARE" is a read-only pointer to data tables. However, to share views across accounts they must be secure views. 

I have updated the Terra views to use the secure flag. Once merged this should fix the DBT run error.