### PR TITLE
Label and dupe cleanup

### DIFF
--- a/models/ethereum/ethereum__events_emitted.sql
+++ b/models/ethereum/ethereum__events_emitted.sql
@@ -4,7 +4,7 @@
   unique_key = 'block_id',
   incremental_strategy = 'delete+insert',
   cluster_by = ['block_timestamp', 'contract_address'],
-  tags = ['snowflake', 'ethereum', 'events_emitted', 'address_labels', 'ab_test']
+  tags = ['snowflake', 'ethereum', 'events_emitted', 'address_labels']
 ) }}
 
 WITH eth_labels AS (

--- a/models/ethereum/ethereum__events_emitted.yml
+++ b/models/ethereum/ethereum__events_emitted.yml
@@ -28,9 +28,6 @@ models:
       - name: EVENT_INDEX
         tests:
           - not_null
-      - name: EVENT_INPUTS
-        tests:
-          - not_null
       - name: EVENT_NAME
         tests:
           - not_null
@@ -62,7 +59,6 @@ models:
           - not_null
       - name: TX_TO_ADDRESS
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
       - name: TX_TO_ADDRESS_NAME

--- a/models/ethereum/silver/silver_ethereum__events_emitted.sql
+++ b/models/ethereum/silver/silver_ethereum__events_emitted.sql
@@ -3,14 +3,43 @@
   unique_key = 'block_id || tx_id || event_index',
   incremental_strategy = 'delete+insert',
   cluster_by = ['block_timestamp'],
-  tags = ['snowflake', 'ethereum', 'silver_ethereum','silver_ethereum__events_emitted']
+  tags = ['snowflake', 'ethereum', 'silver_ethereum','silver_ethereum__events_emitted', 'ab_test']
 ) }}
 
-
-select *
-from (
 SELECT
-  system_created_at,
+  *
+FROM
+  (
+    SELECT
+      system_created_at,
+      block_id,
+      block_timestamp,
+      contract_addr,
+      contract_name,
+      event_index,
+      event_inputs,
+      event_name,
+      event_removed,
+      tx_from_addr,
+      tx_id,
+      tx_succeeded,
+      tx_to_addr
+    FROM
+      {{ ref('ethereum_dbt__events_emitted') }}
+    WHERE
+      1 = 1
+
+{% if is_incremental() %}
+AND block_timestamp :: DATE >= (
+  SELECT
+    DATEADD('day', -1, MAX(block_timestamp :: DATE))
+  FROM
+    {{ this }} AS events_emitted
+)
+{% endif %}
+UNION
+SELECT
+  '2000-01-01' :: TIMESTAMP AS system_created_at,
   block_id,
   block_timestamp,
   contract_addr,
@@ -24,9 +53,13 @@ SELECT
   tx_succeeded,
   tx_to_addr
 FROM
-  {{ ref('ethereum_dbt__events_emitted') }}
+  {{ source(
+    'ethereum',
+    'ethereum_events_emitted'
+  ) }}
 WHERE
-  1 = 1
+  block_timestamp :: DATE < '2020-01-13'
+  AND 1 = 1
 
 {% if is_incremental() %}
 AND block_timestamp :: DATE >= (
@@ -37,38 +70,9 @@ AND block_timestamp :: DATE >= (
 )
 {% endif %}
 
-union
-
-SELECT
-  '2000-01-01'::timestamp as system_created_at,
-  block_id,
-  block_timestamp,
-  contract_addr,
-  contract_name,
-  event_index,
-  event_inputs,
-  event_name,
-  event_removed,
-  tx_from_addr,
-  tx_id,
-  tx_succeeded,
-  tx_to_addr
-FROM
-  {{ source('ethereum','ethereum_events_emitted') }}
-WHERE
-  1 = 1
-
-{% if is_incremental() %}
-AND block_timestamp :: DATE >= (
-  SELECT
-    DATEADD('day', -1, MAX(block_timestamp :: DATE))
-  FROM
-    {{ this }} AS events_emitted
-)
-{% endif %}
-
-QUALIFY(rank() over(partition by tx_id order by block_id desc)) = 1
-) a
-qualify(ROW_NUMBER() over(PARTITION BY block_id, tx_id, event_index
+qualify(RANK() over(PARTITION BY tx_id
+ORDER BY
+  block_id DESC)) = 1
+) A qualify(ROW_NUMBER() over(PARTITION BY block_id, tx_id, event_index
 ORDER BY
   system_created_at DESC)) = 1

--- a/models/ethereum/silver/silver_ethereum__events_emitted.sql
+++ b/models/ethereum/silver/silver_ethereum__events_emitted.sql
@@ -58,7 +58,7 @@ FROM
     'ethereum_events_emitted'
   ) }}
 WHERE
-  block_timestamp :: DATE < '2020-01-13'
+  block_id < 9265469
   AND 1 = 1
 
 {% if is_incremental() %}

--- a/models/ethereum/silver/silver_ethereum__events_emitted.sql
+++ b/models/ethereum/silver/silver_ethereum__events_emitted.sql
@@ -3,7 +3,7 @@
   unique_key = 'block_id || tx_id || event_index',
   incremental_strategy = 'delete+insert',
   cluster_by = ['block_timestamp'],
-  tags = ['snowflake', 'ethereum', 'silver_ethereum','silver_ethereum__events_emitted', 'ab_test']
+  tags = ['snowflake', 'ethereum', 'silver_ethereum','silver_ethereum__events_emitted']
 ) }}
 
 SELECT

--- a/models/ethereum/silver/silver_ethereum__events_emitted.yml
+++ b/models/ethereum/silver/silver_ethereum__events_emitted.yml
@@ -25,9 +25,6 @@ models:
       - name: EVENT_INDEX
         tests:
           - not_null
-      - name: EVENT_INPUTS
-        tests:
-          - not_null
       - name: EVENT_NAME
         tests:
           - not_null
@@ -47,6 +44,5 @@ models:
           - not_null
       - name: TX_TO_ADDR
         tests:
-          - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+

--- a/tests/ethereum/ethereum__events_emitted__event_index-assert_no_gap.sql
+++ b/tests/ethereum/ethereum__events_emitted__event_index-assert_no_gap.sql
@@ -1,1 +1,1 @@
-{{ sequence_gaps(ref("ethereum__events_emitted"), ["block_id", "tx_id",], "event_index") }}
+{{ sequence_gaps(ref("ethereum__events_emitted"), [], "block_id") }}


### PR DESCRIPTION
This PR will clean up the contract name field, as well as force null labels to 'unlabeled'. Additionally, by adding a date filter to the pull from silver.ethereum_events_emitted in the silver code we will remove new bad data that is coming from this old model. Lastly, I tweaked some of the tests. Events inputs and the to_address can be null so I removed those tests from both files. The only test currently failing is the no gap test, which is failing correctly as there are some event indexes we have not decoded.  