### PR TITLE
Fixes typo in terra.daily_balances

### DIFF
--- a/models/terra/gold/terra__daily_balances.sql
+++ b/models/terra/gold/terra__daily_balances.sql
@@ -30,7 +30,7 @@ SELECT
   address_labels.l1_label AS address_label_type,
   address_labels.l2_label AS address_label_subtype,
   address_labels.project_name AS address_label,
-  address_labels.address AS address_name,
+  address_labels.address_name AS address_name,
   balance,
   balance * p.price AS balance_usd,
   b.balance_type,


### PR DESCRIPTION
Incorrect reference to address instead of address_name. This will require a full refresh on prod of terra.daily_balances. 