### PR TITLE
An 495/terra peg variance

### DIFF
--- a/models/terra/gold/terra__oracle_prices.sql
+++ b/models/terra/gold/terra__oracle_prices.sql
@@ -19,6 +19,7 @@ WITH prices AS (
     ) }}
   WHERE
     asset_id = '4172'
+    and provider is not null
   GROUP BY
     1,
     2


### PR DESCRIPTION
In prices_V2, there's a 'null' provider with incorrect (low) LUNA pricing. I added a `where provider is not null` clause to the luna prices query in terra.oracle_prices. This eliminates the sharp dips in the console UST peg variance chart.