### PR TITLE
An 578/upgrading schema to 2.8

### DIFF
--- a/models/algorand/gold/algorand__application_call_transaction.sql
+++ b/models/algorand/gold/algorand__application_call_transaction.sql
@@ -14,7 +14,7 @@ SELECT
     app_id,
     tx_type,
     tx_type_name,
-    genisis_hash,
+    genesis_hash,
     tx_message,
     extra
 FROM

--- a/models/algorand/gold/algorand__application_call_transaction.yml
+++ b/models/algorand/gold/algorand__application_call_transaction.yml
@@ -32,7 +32,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null  
       - name: TX_MESSAGE

--- a/models/algorand/gold/algorand__asset_configuration_transaction.sql
+++ b/models/algorand/gold/algorand__asset_configuration_transaction.sql
@@ -16,7 +16,7 @@ SELECT
     asset_parameters,
     tx_type,
     tx_type_name,
-    genisis_hash,
+    genesis_hash,
     tx_message,
     extra
 FROM

--- a/models/algorand/gold/algorand__asset_configuration_transaction.yml
+++ b/models/algorand/gold/algorand__asset_configuration_transaction.yml
@@ -36,7 +36,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null          
       - name: TX_MESSAGE

--- a/models/algorand/gold/algorand__asset_freeze_transaction.sql
+++ b/models/algorand/gold/algorand__asset_freeze_transaction.sql
@@ -16,7 +16,7 @@ SELECT
     fee,
     tx_type,
     tx_type_name,
-    genisis_hash,
+    genesis_hash,
     tx_message,
     extra
 FROM

--- a/models/algorand/gold/algorand__asset_freeze_transaction.yml
+++ b/models/algorand/gold/algorand__asset_freeze_transaction.yml
@@ -37,7 +37,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/algorand/gold/algorand__asset_transfer_transaction.sql
+++ b/models/algorand/gold/algorand__asset_transfer_transaction.sql
@@ -18,7 +18,7 @@ SELECT
     asset_transferred,
     tx_type,
     tx_type_name,
-    genisis_hash,
+    genesis_hash,
     tx_message,
     extra
 FROM

--- a/models/algorand/gold/algorand__asset_transfer_transaction.yml
+++ b/models/algorand/gold/algorand__asset_transfer_transaction.yml
@@ -27,7 +27,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/algorand/gold/algorand__block.sql
+++ b/models/algorand/gold/algorand__block.sql
@@ -8,7 +8,7 @@ SELECT
     block_timestamp,
     rewardslevel,
     network,
-    genisis_hash,
+    genesis_hash,
     prev_block_hash,
     txn_root,
     header

--- a/models/algorand/gold/algorand__block.yml
+++ b/models/algorand/gold/algorand__block.yml
@@ -18,7 +18,7 @@ models:
       - name: NETWORK
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: PREV_BLOCK_HASH

--- a/models/algorand/gold/algorand__key_registration_transaction.sql
+++ b/models/algorand/gold/algorand__key_registration_transaction.sql
@@ -19,7 +19,7 @@ SELECT
     vote_keydilution,
     tx_type,
     tx_type_name,
-    genisis_hash,
+    genesis_hash,
     tx_message,
     extra
 FROM

--- a/models/algorand/gold/algorand__key_registration_transaction.yml
+++ b/models/algorand/gold/algorand__key_registration_transaction.yml
@@ -34,7 +34,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/algorand/gold/algorand__payment_transaction.sql
+++ b/models/algorand/gold/algorand__payment_transaction.sql
@@ -16,7 +16,7 @@ SELECT
     fee,
     tx_type,
     tx_type_name,
-    genisis_hash,
+    genesis_hash,
     tx_message,
     extra
 FROM

--- a/models/algorand/gold/algorand__payment_transaction.yml
+++ b/models/algorand/gold/algorand__payment_transaction.yml
@@ -27,7 +27,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/algorand/gold/algorand__transactions.sql
+++ b/models/algorand/gold/algorand__transactions.sql
@@ -14,7 +14,7 @@ SELECT
     fee,
     tx_type,
     tx_type_name,
-    genisis_hash,
+    genesis_hash,
     tx_message,
     extra
 FROM

--- a/models/algorand/gold/algorand__transactions.yml
+++ b/models/algorand/gold/algorand__transactions.yml
@@ -21,7 +21,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/algorand/silver/silver_algorand__application_call_transaction.sql
+++ b/models/algorand/silver/silver_algorand__application_call_transaction.sql
@@ -27,9 +27,9 @@ WITH allTXN AS (
     txn :txn :apid AS app_id,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
       ELSE txn :txn :gh :: STRING
-    END AS genisis_hash,
+    END AS genesis_hash,
     txn AS tx_message,
     extra,
     b._FIVETRAN_SYNCED AS _FIVETRAN_SYNCED
@@ -62,7 +62,7 @@ SELECT
   app_id,
   csv.type AS tx_type,
   csv.name AS tx_type_name,
-  genisis_hash,
+  genesis_hash,
   tx_message,
   extra,
   concat_ws(

--- a/models/algorand/silver/silver_algorand__application_call_transaction.sql
+++ b/models/algorand/silver/silver_algorand__application_call_transaction.sql
@@ -12,11 +12,11 @@ WITH allTXN AS (
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.txn_txn_id :: text
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
       ELSE b.txid :: text
     END AS tx_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN 'true'
+      WHEN b.txid IS NULL THEN 'true'
       ELSE 'false'
     END AS inner_tx,
     txn :txn :snd :: text AS sender,
@@ -27,7 +27,7 @@ WITH allTXN AS (
     txn :txn :apid AS app_id,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
       ELSE txn :txn :gh :: STRING
     END AS genisis_hash,
     txn AS tx_message,

--- a/models/algorand/silver/silver_algorand__application_call_transaction.yml
+++ b/models/algorand/silver/silver_algorand__application_call_transaction.yml
@@ -32,7 +32,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null  
       - name: TX_MESSAGE

--- a/models/algorand/silver/silver_algorand__asset_configuration_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_configuration_transaction.sql
@@ -29,9 +29,9 @@ WITH allTXN AS (
     txn :txn :apar AS asset_parameters,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
       ELSE txn :txn :gh :: STRING
-    END AS genisis_hash,
+    END AS genesis_hash,
     txn AS tx_message,
     extra,
     b._FIVETRAN_SYNCED AS _FIVETRAN_SYNCED
@@ -65,7 +65,7 @@ SELECT
   asset_parameters,
   csv.type AS tx_type,
   csv.name AS tx_type_name,
-  genisis_hash,
+  genesis_hash,
   tx_message,
   extra,
   concat_ws(

--- a/models/algorand/silver/silver_algorand__asset_configuration_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_configuration_transaction.sql
@@ -12,11 +12,11 @@ WITH allTXN AS (
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.txn_txn_id :: text
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
       ELSE b.txid :: text
     END AS tx_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN 'true'
+      WHEN b.txid IS NULL THEN 'true'
       ELSE 'false'
     END AS inner_tx,
     asset AS asset_id,
@@ -29,7 +29,7 @@ WITH allTXN AS (
     txn :txn :apar AS asset_parameters,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
       ELSE txn :txn :gh :: STRING
     END AS genisis_hash,
     txn AS tx_message,

--- a/models/algorand/silver/silver_algorand__asset_configuration_transaction.yml
+++ b/models/algorand/silver/silver_algorand__asset_configuration_transaction.yml
@@ -36,7 +36,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null          
       - name: TX_MESSAGE

--- a/models/algorand/silver/silver_algorand__asset_freeze_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_freeze_transaction.sql
@@ -12,11 +12,11 @@ WITH allTXN AS (
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.txn_txn_id :: text
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
       ELSE b.txid :: text
     END AS tx_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN 'true'
+      WHEN b.txid IS NULL THEN 'true'
       ELSE 'false'
     END AS inner_tx,
     asset AS asset_id,
@@ -29,7 +29,7 @@ WITH allTXN AS (
     ) AS fee,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
       ELSE txn :txn :gh :: STRING
     END AS genisis_hash,
     txn AS tx_message,

--- a/models/algorand/silver/silver_algorand__asset_freeze_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_freeze_transaction.sql
@@ -29,9 +29,9 @@ WITH allTXN AS (
     ) AS fee,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
       ELSE txn :txn :gh :: STRING
-    END AS genisis_hash,
+    END AS genesis_hash,
     txn AS tx_message,
     extra,
     b._FIVETRAN_SYNCED AS _FIVETRAN_SYNCED
@@ -67,7 +67,7 @@ SELECT
   fee,
   csv.type AS tx_type,
   csv.name AS tx_type_name,
-  genisis_hash,
+  genesis_hash,
   tx_message,
   extra,
   concat_ws(

--- a/models/algorand/silver/silver_algorand__asset_freeze_transaction.yml
+++ b/models/algorand/silver/silver_algorand__asset_freeze_transaction.yml
@@ -37,7 +37,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/algorand/silver/silver_algorand__asset_transfer_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_transfer_transaction.sql
@@ -31,9 +31,9 @@ WITH allTXN AS (
     txn :txn :xaid AS asset_transferred,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
       ELSE txn :txn :gh :: STRING
-    END AS genisis_hash,
+    END AS genesis_hash,
     txn AS tx_message,
     extra,
     b._FIVETRAN_SYNCED AS _FIVETRAN_SYNCED
@@ -73,7 +73,7 @@ SELECT
   asset_transferred,
   csv.type AS tx_type,
   csv.name AS tx_type_name,
-  genisis_hash,
+  genesis_hash,
   tx_message,
   extra,
   concat_ws(

--- a/models/algorand/silver/silver_algorand__asset_transfer_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_transfer_transaction.sql
@@ -12,11 +12,11 @@ WITH allTXN AS (
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.txn_txn_id :: text
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
       ELSE b.txid :: text
     END AS tx_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN 'true'
+      WHEN b.txid IS NULL THEN 'true'
       ELSE 'false'
     END AS inner_tx,
     asset AS asset_id,
@@ -31,7 +31,7 @@ WITH allTXN AS (
     txn :txn :xaid AS asset_transferred,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
       ELSE txn :txn :gh :: STRING
     END AS genisis_hash,
     txn AS tx_message,

--- a/models/algorand/silver/silver_algorand__asset_transfer_transaction.yml
+++ b/models/algorand/silver/silver_algorand__asset_transfer_transaction.yml
@@ -31,7 +31,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/algorand/silver/silver_algorand__block.sql
+++ b/models/algorand/silver/silver_algorand__block.sql
@@ -10,7 +10,7 @@ SELECT
   realtime :: TIMESTAMP AS block_timestamp,
   rewardslevel AS rewardslevel,
   header :gen :: STRING AS network,
-  header :gh :: STRING AS genisis_hash,
+  header :gh :: STRING AS genesis_hash,
   header :prev :: STRING AS prev_block_hash,
   header :txn :: STRING AS txn_root,
   header,

--- a/models/algorand/silver/silver_algorand__block.yml
+++ b/models/algorand/silver/silver_algorand__block.yml
@@ -18,7 +18,7 @@ models:
       - name: NETWORK
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: PREV_BLOCK_HASH

--- a/models/algorand/silver/silver_algorand__inner_txids.sql
+++ b/models/algorand/silver/silver_algorand__inner_txids.sql
@@ -41,7 +41,7 @@ SELECT
   f.txid AS txn_txn_id,
   er.intra AS inner_intra,
   f.intra AS txn_intra,
-  f.gh AS genisis_hash,
+  f.gh AS genesis_hash,
   concat_ws(
     '-',
     er.round :: STRING,

--- a/models/algorand/silver/silver_algorand__inner_txids.sql
+++ b/models/algorand/silver/silver_algorand__inner_txids.sql
@@ -11,6 +11,7 @@ WITH emptyROUNDS AS (
     ROUND,
     intra,
     txn,
+    extra,
     _FIVETRAN_SYNCED
   FROM
     {{ source(
@@ -18,34 +19,26 @@ WITH emptyROUNDS AS (
       'TXN'
     ) }}
   WHERE
-    txid :: STRING = ''
+    txid IS NULL
 ),
 fulljson AS (
   SELECT
     ROUND,
     txid,
     intra,
-    t.value AS message,
-    txn,
     txn :txn :gh :: STRING AS gh
   FROM
     {{ source(
       'algorand',
       'TXN'
-    ) }},
-    LATERAL FLATTEN(
-      input => txn :dt :itx
-    ) t
+    ) }}
   WHERE
-    txn :dt :itx IS NOT NULL
+    txid IS NOT NULL
 )
 SELECT
   f.round AS txn_round,
   er.round AS inner_round,
   f.txid AS txn_txn_id,
-  f.txn AS txn_body,
-  f.message AS txn_inner_txn,
-  er.txn AS inner_message,
   er.intra AS inner_intra,
   f.intra AS txn_intra,
   f.gh AS genisis_hash,
@@ -58,7 +51,7 @@ SELECT
 FROM
   emptyROUNDS er
   LEFT JOIN fulljson f
-  ON er.txn = f.message
+  ON er.extra :"root-intra" :: NUMBER = f.intra
   AND er.round = f.round
 WHERE
   f.round IS NOT NULL

--- a/models/algorand/silver/silver_algorand__inner_txids.yml
+++ b/models/algorand/silver/silver_algorand__inner_txids.yml
@@ -16,15 +16,6 @@ models:
       - name: txn_txn_id
         tests:
           - not_null
-      - name: txn_body
-        tests:
-          - not_null
-      - name: txn_inner_txn
-        tests:
-          - not_null
-      - name: inner_message
-        tests:
-          - not_null
       - name: inner_intra
         tests:
           - not_null

--- a/models/algorand/silver/silver_algorand__inner_txids.yml
+++ b/models/algorand/silver/silver_algorand__inner_txids.yml
@@ -22,6 +22,6 @@ models:
       - name: txn_intra
         tests:
           - not_null
-      - name: genisis_hash
+      - name: genesis_hash
         tests:
           - not_null

--- a/models/algorand/silver/silver_algorand__key_registration_transaction.sql
+++ b/models/algorand/silver/silver_algorand__key_registration_transaction.sql
@@ -12,11 +12,11 @@ WITH allTXN AS (
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.txn_txn_id :: text
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
       ELSE b.txid :: text
     END AS tx_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN 'true'
+      WHEN b.txid IS NULL THEN 'true'
       ELSE 'false'
     END AS inner_tx,
     asset AS asset_id,
@@ -32,7 +32,7 @@ WITH allTXN AS (
     txn :txn :votekd AS vote_keydilution,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
       ELSE txn :txn :gh :: STRING
     END AS genisis_hash,
     txn AS tx_message,

--- a/models/algorand/silver/silver_algorand__key_registration_transaction.sql
+++ b/models/algorand/silver/silver_algorand__key_registration_transaction.sql
@@ -32,9 +32,9 @@ WITH allTXN AS (
     txn :txn :votekd AS vote_keydilution,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
       ELSE txn :txn :gh :: STRING
-    END AS genisis_hash,
+    END AS genesis_hash,
     txn AS tx_message,
     extra,
     b._FIVETRAN_SYNCED AS _FIVETRAN_SYNCED
@@ -75,7 +75,7 @@ SELECT
   vote_keydilution,
   csv.type AS tx_type,
   csv.name AS tx_type_name,
-  genisis_hash,
+  genesis_hash,
   tx_message,
   extra,
   concat_ws(

--- a/models/algorand/silver/silver_algorand__key_registration_transaction.yml
+++ b/models/algorand/silver/silver_algorand__key_registration_transaction.yml
@@ -34,7 +34,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/algorand/silver/silver_algorand__payment_transaction.sql
+++ b/models/algorand/silver/silver_algorand__payment_transaction.sql
@@ -32,9 +32,9 @@ WITH allTXN AS (
     ) AS fee,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
       ELSE txn :txn :gh :: STRING
-    END AS genisis_hash,
+    END AS genesis_hash,
     txn AS tx_message,
     extra,
     b._FIVETRAN_SYNCED AS _FIVETRAN_SYNCED
@@ -70,7 +70,7 @@ SELECT
   fee,
   csv.type AS tx_type,
   csv.name AS tx_type_name,
-  genisis_hash,
+  genesis_hash,
   tx_message,
   extra,
   concat_ws(

--- a/models/algorand/silver/silver_algorand__payment_transaction.sql
+++ b/models/algorand/silver/silver_algorand__payment_transaction.sql
@@ -12,11 +12,11 @@ WITH allTXN AS (
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.txn_txn_id :: text
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
       ELSE b.txid :: text
     END AS tx_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN 'true'
+      WHEN b.txid IS NULL THEN 'true'
       ELSE 'false'
     END AS inner_tx,
     asset AS asset_id,
@@ -32,7 +32,7 @@ WITH allTXN AS (
     ) AS fee,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
       ELSE txn :txn :gh :: STRING
     END AS genisis_hash,
     txn AS tx_message,

--- a/models/algorand/silver/silver_algorand__payment_transaction.yml
+++ b/models/algorand/silver/silver_algorand__payment_transaction.yml
@@ -31,7 +31,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/algorand/silver/silver_algorand__transaction_participation.sql
+++ b/models/algorand/silver/silver_algorand__transaction_participation.sql
@@ -5,11 +5,28 @@
   tags = ['snowflake', 'algorand', 'transaction_participation', 'silver_algorand']
 ) }}
 
+WITH inner_tx_individual AS(
+
+  SELECT
+    ROUND AS block_id,
+    intra,
+    addr :: text AS address,
+    MIN(_FIVETRAN_SYNCED) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand',
+      'TXN_PARTICIPATION'
+    ) }}
+  GROUP BY
+    block_id,
+    intra,
+    address
+)
 SELECT
-  ROUND AS block_id,
+  block_id,
   intra,
   algorand_decode_hex_addr(
-    addr :: text
+    address :: text
   ) AS address,
   concat_ws(
     '-',
@@ -19,10 +36,7 @@ SELECT
   ) AS _unique_key,
   _FIVETRAN_SYNCED
 FROM
-  {{ source(
-    'algorand',
-    'TXN_PARTICIPATION'
-  ) }}
+  inner_tx_individual
 WHERE
   1 = 1
 

--- a/models/algorand/silver/silver_algorand__transactions.sql
+++ b/models/algorand/silver/silver_algorand__transactions.sql
@@ -30,9 +30,9 @@ WITH allTXN AS (
     ) AS fee,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
       ELSE txn :txn :gh :: STRING
-    END AS genisis_hash,
+    END AS genesis_hash,
     txn AS tx_message,
     extra,
     b._FIVETRAN_SYNCED AS _FIVETRAN_SYNCED
@@ -62,7 +62,7 @@ SELECT
   fee,
   csv.type AS tx_type,
   csv.name AS tx_type_name,
-  genisis_hash,
+  genesis_hash,
   tx_message,
   extra,
   concat_ws(

--- a/models/algorand/silver/silver_algorand__transactions.sql
+++ b/models/algorand/silver/silver_algorand__transactions.sql
@@ -12,11 +12,11 @@ WITH allTXN AS (
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.txn_txn_id :: text
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
       ELSE b.txid :: text
     END AS tx_id,
     CASE
-      WHEN b.txid :: STRING = '' THEN 'true'
+      WHEN b.txid IS NULL THEN 'true'
       ELSE 'false'
     END AS inner_tx,
     CASE
@@ -30,7 +30,7 @@ WITH allTXN AS (
     ) AS fee,
     txn :txn :type :: STRING AS tx_type,
     CASE
-      WHEN b.txid :: STRING = '' THEN ft.genisis_hash :: text
+      WHEN b.txid IS NULL THEN ft.genisis_hash :: text
       ELSE txn :txn :gh :: STRING
     END AS genisis_hash,
     txn AS tx_message,

--- a/models/algorand/silver/silver_algorand__transactions.yml
+++ b/models/algorand/silver/silver_algorand__transactions.yml
@@ -25,7 +25,7 @@ models:
       - name: TX_TYPE_NAME
         tests:
           - not_null
-      - name: GENISIS_HASH
+      - name: GENESIS_HASH
         tests:
           - not_null
       - name: TX_MESSAGE

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -138,7 +138,7 @@ sources:
     tables:
       - name: daily_balances
   - name: algorand
-    schema: BRONZE_ALGORAND_2_6_4_PUBLIC
+    schema: BRONZE_ALGORAND_2_8_0_PUBLIC
     tables:
       - name: ACCOUNT
       - name: ACCOUNT_APP


### PR DESCRIPTION
-Upgrade schema algorand schema to 2.8
-Update inner transaction table to reflect new extra field that contains txid of parent transaction
-update case statements to reflect null txIDs for 2.8 indexer data rather than empty ids from the 2.6 data