### PR TITLE
fixes issue where contract name was pulling in an address

### DIFF
--- a/models/ethereum/ethereum__events_emitted.sql
+++ b/models/ethereum/ethereum__events_emitted.sql
@@ -29,7 +29,7 @@ SELECT
   to_labels.project_name as tx_to_label,
   to_labels.address_name as tx_to_address_name,
   CONTRACT_ADDR AS contract_address,
-  COALESCE(contract_labels.address,CONTRACT_NAME) AS contract_name,
+  COALESCE(contract_labels.address_name, CONTRACT_NAME) AS contract_name,
   TX_SUCCEEDED AS tx_succeeded
 FROM {{ ref('silver_ethereum__events_emitted') }} b
 


### PR DESCRIPTION
Fixes issue where ethereum.events_emitted was pulling in contract address in the contract name column. 
Requires full refresh of ethereum.events_emitted