### PR TITLE
Update to contract name and disabled tests

### DIFF
--- a/models/polygon/polygon__events_emitted.sql
+++ b/models/polygon/polygon__events_emitted.sql
@@ -39,7 +39,7 @@ SELECT
   to_labels.project_name as tx_to_label,
   to_labels.address_name as tx_to_address_name,
   CONTRACT_ADDRESS AS contract_address,
-  COALESCE(contract_labels.address,CONTRACT_NAME) AS contract_name,
+  COALESCE(contract_labels.address_name, CONTRACT_NAME) AS contract_name,
   TX_SUCCEEDED AS tx_succeeded
 FROM {{ ref('silver_polygon__events_emitted')}} b
 

--- a/models/polygon/polygon__events_emitted.yml
+++ b/models/polygon/polygon__events_emitted.yml
@@ -24,7 +24,8 @@ models:
               regex: 0[xX][0-9a-fA-F]+
       - name: CONTRACT_NAME
         tests:
-          - not_null
+          - not_null:
+              enabled: False # Crosschain labels will not be available for all addresses
       - name: EVENT_INDEX
         tests:
           - not_null
@@ -44,16 +45,20 @@ models:
               regex: 0[xX][0-9a-fA-F]+
       - name: TX_FROM_ADDRESS_NAME
         tests:
-          - not_null
+          - not_null: 
+              enabled: False # Crosschain labels will not be available for all addresses
       - name: TX_FROM_LABEL
         tests:
-          - not_null
+          - not_null: 
+              enabled: False # Crosschain labels will not be available for all addresses
       - name: TX_FROM_LABEL_SUBTYPE
         tests:
-          - not_null
+          - not_null: 
+              enabled: False # Crosschain labels will not be available for all addresses
       - name: TX_FROM_LABEL_TYPE
         tests:
-          - not_null
+          - not_null: 
+              enabled: False # Crosschain labels will not be available for all addresses
       - name: TX_ID
         tests:
           - not_null
@@ -67,13 +72,17 @@ models:
               regex: 0[xX][0-9a-fA-F]+
       - name: TX_TO_ADDRESS_NAME
         tests:
-          - not_null
+          - not_null:
+              enabled: False # Crosschain labels will not be available for all addresses
       - name: TX_TO_LABEL
         tests:
-          - not_null
+          - not_null: 
+              enabled: False # Crosschain labels will not be available for all addresses
       - name: TX_TO_LABEL_SUBTYPE
         tests:
-          - not_null
+          - not_null: 
+              enabled: False # Crosschain labels will not be available for all addresses
       - name: TX_TO_LABEL_TYPE
         tests:
-          - not_null
+          - not_null: 
+              enabled: False # Crosschain labels will not be available for all addresses


### PR DESCRIPTION
Fixes bug where contract_names field was pulling in addresses instead of names. 
Disabled not null tests on columns being pulled from crosschain.address_labels table (we do not have labels for all polygon addresses and contracts - expect nulls)