### PR TITLE
reduce test run time by limiting range of data to run test

### DIFF
--- a/models/solana/silver/silver_solana__votes.yml
+++ b/models/solana/silver/silver_solana__votes.yml
@@ -6,6 +6,7 @@ models:
           combination_of_columns:
             - BLOCK_ID
             - TX_ID
+          where: block_timestamp::date >= current_date - 2
     columns:
       - name: BLOCK_TIMESTAMP
         tests:


### PR DESCRIPTION
- Votes unique key tests take a long time to run due to table size.  Reduce data range to cover what incremental load would be loading.