### PR TITLE
Removed refs to legacy tags

### DIFF
--- a/models/consoles/terra/consoles_terra__dapp_flows.sql
+++ b/models/consoles/terra/consoles_terra__dapp_flows.sql
@@ -19,7 +19,7 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
            WHEN event_from_label_type IN('project', 'defi', 'dapp') THEN 'dApps'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
@@ -27,7 +27,7 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
            WHEN event_to_label_type IN('project', 'defi', 'dapp') THEN 'dApps'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -48,7 +48,7 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
            WHEN event_from_label_type IN('project', 'defi', 'dapp') THEN 'dApps'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
@@ -56,7 +56,7 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
            WHEN event_to_label_type IN('project', 'defi', 'dapp') THEN 'dApps'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -77,7 +77,7 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
            WHEN event_from_label_type IN('project', 'defi', 'dapp') THEN 'dApps'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
@@ -85,7 +85,7 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
            WHEN event_to_label_type IN('project', 'defi', 'dapp') THEN 'dApps'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -105,7 +105,7 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
            WHEN event_from_label_type IN('project', 'defi', 'dapp') THEN 'dApps'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
@@ -113,7 +113,7 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
            WHEN event_to_label_type IN('project', 'defi', 'dapp') THEN 'dApps'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,

--- a/models/consoles/terra/consoles_terra__exchange_flows.sql
+++ b/models/consoles/terra/consoles_terra__exchange_flows.sql
@@ -18,14 +18,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -45,14 +45,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -72,14 +72,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -98,14 +98,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,

--- a/models/consoles/terra/consoles_terra__foundation_flows.sql
+++ b/models/consoles/terra/consoles_terra__foundation_flows.sql
@@ -18,14 +18,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -45,14 +45,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -72,14 +72,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -98,14 +98,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,

--- a/models/consoles/terra/consoles_terra__operator_flows.sql
+++ b/models/consoles/terra/consoles_terra__operator_flows.sql
@@ -18,14 +18,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -45,14 +45,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -72,14 +72,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -98,14 +98,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,

--- a/models/consoles/terra/consoles_terra__token_breakdown.sql
+++ b/models/consoles/terra/consoles_terra__token_breakdown.sql
@@ -20,7 +20,7 @@ SELECT block_timestamp::date as metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra' and start_date >= current_date - 180 ) AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS segment,
        sum(event_amount) AS outflow
@@ -37,7 +37,7 @@ SELECT block_timestamp::date as metric_date,
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra' and start_date >= current_date - 180 ) AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS segment,
        sum(event_amount) AS inflow
@@ -54,7 +54,7 @@ SELECT block_timestamp::date as metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra' and start_date >= current_date - 180 ) AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS segment,
        sum(event_amount) AS outflow
@@ -70,7 +70,7 @@ SELECT block_timestamp::date as metric_date,
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra' and start_date >= current_date - 180 ) AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS segment,
        sum(event_amount) AS inflow
@@ -87,7 +87,7 @@ SELECT block_timestamp::date as metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra' and start_date >= current_date - 180 ) AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS segment,
        sum(event_amount) AS outflow
@@ -103,7 +103,7 @@ SELECT block_timestamp::date as metric_date,
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra' and start_date >= current_date - 180 ) AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS segment,
        sum(event_amount) AS inflow
@@ -120,7 +120,7 @@ SELECT block_timestamp::date as metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra' and start_date >= current_date - 180 ) AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS segment,
        sum(event_amount) AS outflow
@@ -136,7 +136,7 @@ SELECT block_timestamp::date as metric_date,
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra' and start_date >= current_date - 180 ) AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS segment,
        sum(event_amount) AS inflow

--- a/models/consoles/terra/consoles_terra__top_holder_flows.sql
+++ b/models/consoles/terra/consoles_terra__top_holder_flows.sql
@@ -18,14 +18,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'krt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'KRT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -45,14 +45,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'sdt_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'SDT') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -72,14 +72,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'luna_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'LUNA') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,
@@ -98,14 +98,14 @@ SELECT date_trunc('day', block_timestamp) AS metric_date,
            WHEN event_from_label_type = 'operator' THEN 'Operator'
            WHEN event_from IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_from_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_from IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_from_label_type IS NULL THEN 'Top Holder'
+           WHEN event_from IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_from_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS from_segment,
        CASE
            WHEN event_to_label_type = 'operator' THEN 'Operator'
            WHEN event_to IN('terra1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8pm7utl','terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6') THEN 'Foundation'
            WHEN event_to_label_type IN('distributor','cex') THEN 'Exchanges'
-           WHEN event_to IN(select distinct address from {{ ref('silver_crosschain__address_tags') }} where tag_type = 'ust_top_holder' and blockchain = 'terra') AND event_to_label_type IS NULL THEN 'Top Holder'
+           WHEN event_to IN(SELECT address FROM {{ ref('consoles_terra__top_holders') }} WHERE currency = 'UST') AND event_to_label_type IS NULL THEN 'Top Holder'
            ELSE 'Smaller Wallets'
        END AS to_segment,
        event_currency,

--- a/models/consoles/terra/consoles_terra__top_holders.sql
+++ b/models/consoles/terra/consoles_terra__top_holders.sql
@@ -1,0 +1,61 @@
+{{ config(
+  materialized = 'view',
+  unique_key = "CONCAT_WS('-', address, currency, avg_balance)",
+  tags = ['snowflake', 'console', 'terra', 'top_holders']
+) }}
+
+with top_holders as (
+SELECT * from (
+SELECT 
+address,
+currency,
+AVG(balance) as avg_balance
+FROM {{ ref('terra__daily_balances') }}
+WHERE currency = 'KRT'
+AND date >= current_date - 30
+GROUP BY address, currency
+ORDER BY avg_balance desc
+LIMIT 1000
+)
+  
+UNION
+ 
+(SELECT 
+address,
+currency,
+AVG(balance) as avg_balance
+FROM {{ ref('terra__daily_balances') }}
+WHERE currency = 'SDT'
+AND date >= current_date - 30
+GROUP BY address, currency
+ORDER BY avg_balance desc
+LIMIT 1000)
+
+UNION
+  
+(SELECT 
+address,
+currency,
+AVG(balance) as avg_balance
+FROM {{ ref('terra__daily_balances') }}
+WHERE currency = 'LUNA'
+AND date >= current_date - 30
+GROUP BY address, currency
+ORDER BY avg_balance desc
+LIMIT 1000)
+  
+UNION
+
+(SELECT 
+address,
+currency,
+AVG(balance) as avg_balance
+FROM {{ ref('terra__daily_balances') }}
+WHERE currency = 'UST'
+AND date >= current_date - 30
+GROUP BY address, currency
+ORDER BY avg_balance desc
+LIMIT 1000)
+)
+
+SELECT * FROM top_holders

--- a/models/consoles/terra/consoles_terra__top_holders.yml
+++ b/models/consoles/terra/consoles_terra__top_holders.yml
@@ -1,0 +1,26 @@
+version: 2
+models:
+  - name: consoles_terra__top_holders
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - ADDRESS
+            - CURRENCY
+    columns:
+      - name: ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: terra[0-9a-zA-Z]{39,40}
+      - name: CURRENCY
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - varchar 
+      - name: AVG_BALANCE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - float


### PR DESCRIPTION
Removed legacy udm_address_tags ({{ ref('silver_crosschain__address_tags') }}) references from following models:

consoles_terra__dapp_flows.sql
consoles_terra__exchange_flows.sql
consoles_terra__foundation_flows.sql
consoles_terra__operator_flows.sql
consoles_terra__token_breakdown.sql
consoles_terra__top_holder_flows.sql

Added consoles_terra__top_holders.sql to replace tags.
All tests passing