### PR TITLE
adds gold address labels tables to each schema

### DIFF
--- a/models/algorand/gold/algorand__labels.sql
+++ b/models/algorand/gold/algorand__labels.sql
@@ -1,6 +1,6 @@
 {{ config(
       materialized='view',
-      tags=['snowflake', 'terra_views', 'labels', 'terra_labels', 'address_labels']  
+      tags=['snowflake', 'algorand_views', 'labels', 'algorand_labels', 'address_labels']  
     ) 
 }}
 
@@ -13,4 +13,4 @@ SELECT
   project_name as label, 
   address_name as address_name
 FROM {{ref('silver_crosschain__address_labels')}}
-WHERE blockchain = 'terra'
+WHERE blockchain = 'algorand'

--- a/models/algorand/gold/algorand__labels.yml
+++ b/models/algorand/gold/algorand__labels.yml
@@ -1,0 +1,44 @@
+version: 2
+models:
+  - name: algorand__labels
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCKCHAIN
+            - CREATOR
+            - ADDRESS
+    columns:
+      - name: BLOCKCHAIN
+        description: The name of the blockchain
+        tests:
+          - not_null
+      - name: CREATOR
+        description: The name of the creator of the label
+        tests:
+          - not_null
+      - name: LABEL_TYPE
+        description: A high-level category describing the addresses main function or ownership
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set: ['flotsam', 'nft', 'defi', 'dex', 'cex', 'dapp', 'token', 'operator', 'layer2', 'chadmin']
+      - name: LABEL_SUBTYPE
+        description: A sub-category nested within label type providing further detail
+        tests:
+          - not_null
+      - name: LABEL
+        description: Name of the controlling entity of the address
+        tests:
+          - not_null
+      - name: ADDRESS_NAME
+        description: Name of the controlling entity of the address
+        tests:
+          - not_null
+      - name: ADDRESS
+        description: Address that the label is for 
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_value_lengths_to_equal:
+              value: 58
+              where: BLOCKCHAIN = 'algorand'
+      

--- a/models/ethereum/ethereum__labels.sql
+++ b/models/ethereum/ethereum__labels.sql
@@ -1,6 +1,6 @@
 {{ config(
       materialized='view',
-      tags=['snowflake', 'terra_views', 'labels', 'terra_labels', 'address_labels']  
+      tags=['snowflake', 'ethereum_views', 'labels', 'ethereum_labels', 'address_labels']  
     ) 
 }}
 
@@ -13,4 +13,4 @@ SELECT
   project_name as label, 
   address_name as address_name
 FROM {{ref('silver_crosschain__address_labels')}}
-WHERE blockchain = 'terra'
+WHERE blockchain = 'ethereum'

--- a/models/ethereum/ethereum__labels.yml
+++ b/models/ethereum/ethereum__labels.yml
@@ -1,0 +1,45 @@
+version: 2
+models:
+  - name: ethereum__labels
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCKCHAIN
+            - CREATOR
+            - ADDRESS
+    columns:
+      - name: BLOCKCHAIN
+        description: The name of the blockchain
+        tests:
+          - not_null
+      - name: CREATOR
+        description: The name of the creator of the label
+        tests:
+          - not_null
+      - name: LABEL_TYPE
+        description: A high-level category describing the addresses main function or ownership
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set: ['flotsam', 'nft', 'defi', 'dex', 'cex', 'dapp', 'token', 'operator', 'layer2', 'chadmin']
+      - name: LABEL_SUBTYPE
+        description: A sub-category nested within label type providing further detail
+        tests:
+          - not_null
+      - name: LABEL
+        description: Name of the controlling entity of the address
+        tests:
+          - not_null
+      - name: ADDRESS_NAME
+        description: Name of the controlling entity of the address
+        tests:
+          - not_null: 
+              enabled: False # Bug in deposit wallet algorithm causing nulls in this field
+      - name: ADDRESS
+        description: Address that the label is for 
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+              where: BLOCKCHAIN = 'ethereum'
+      

--- a/models/gold/gold__flow_labels.sql
+++ b/models/gold/gold__flow_labels.sql
@@ -1,16 +1,16 @@
 {{ config(
       materialized='view',
-      tags=['snowflake', 'terra_views', 'labels', 'terra_labels', 'address_labels']  
+      tags=['snowflake', 'flow_views', 'labels', 'flow_labels', 'address_labels']  
     ) 
 }}
 
 SELECT
-  blockchain, 
-  creator, 
+  blockchain,
+  creator,  
   address,
   l1_label as label_type,
   l2_label as label_subtype,
   project_name as label, 
   address_name as address_name
 FROM {{ref('silver_crosschain__address_labels')}}
-WHERE blockchain = 'terra'
+WHERE blockchain = 'flow'

--- a/models/gold/gold__flow_labels.yml
+++ b/models/gold/gold__flow_labels.yml
@@ -1,0 +1,40 @@
+version: 2
+models:
+  - name: gold__flow_labels
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCKCHAIN
+            - CREATOR
+            - ADDRESS
+    columns:
+      - name: BLOCKCHAIN
+        description: The name of the blockchain
+        tests:
+          - not_null
+      - name: CREATOR
+        description: The name of the creator of the label
+        tests:
+          - not_null
+      - name: LABEL_TYPE
+        description: A high-level category describing the addresses main function or ownership
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set: ['flotsam', 'nft', 'defi', 'dex', 'cex', 'dapp', 'token', 'operator', 'layer2', 'chadmin']
+      - name: LABEL_SUBTYPE
+        description: A sub-category nested within label type providing further detail
+        tests:
+          - not_null
+      - name: LABEL
+        description: Name of the controlling entity of the address
+        tests:
+          - not_null
+      - name: ADDRESS_NAME
+        description: Name of the controlling entity of the address
+        tests:
+          - not_null
+      - name: ADDRESS
+        description: Address that the label is for 
+        tests:
+          - not_null

--- a/models/polygon/polygon__labels.sql
+++ b/models/polygon/polygon__labels.sql
@@ -1,6 +1,6 @@
 {{ config(
       materialized='view',
-      tags=['snowflake', 'terra_views', 'labels', 'terra_labels', 'address_labels']  
+      tags=['snowflake', 'polygon_views', 'labels', 'polygon_labels', 'address_labels']  
     ) 
 }}
 
@@ -13,4 +13,4 @@ SELECT
   project_name as label, 
   address_name as address_name
 FROM {{ref('silver_crosschain__address_labels')}}
-WHERE blockchain = 'terra'
+WHERE blockchain = 'polygon'

--- a/models/polygon/polygon__labels.yml
+++ b/models/polygon/polygon__labels.yml
@@ -1,0 +1,43 @@
+version: 2
+models:
+  - name: polygon__labels
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCKCHAIN
+            - CREATOR
+            - ADDRESS
+    columns:
+      - name: BLOCKCHAIN
+        description: The name of the blockchain
+        tests:
+          - not_null
+      - name: CREATOR
+        description: The name of the creator of the label
+        tests:
+          - not_null
+      - name: LABEL_TYPE
+        description: A high-level category describing the addresses main function or ownership
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_set:
+              value_set: ['flotsam', 'nft', 'defi', 'dex', 'cex', 'dapp', 'token', 'operator', 'layer2', 'chadmin']
+      - name: LABEL_SUBTYPE
+        description: A sub-category nested within label type providing further detail
+        tests:
+          - not_null
+      - name: LABEL
+        description: Name of the controlling entity of the address
+        tests:
+          - not_null
+      - name: ADDRESS_NAME
+        description: Name of the controlling entity of the address
+        tests:
+          - not_null
+      - name: ADDRESS
+        description: Address that the label is for 
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex: 
+              regex: 0[xX][0-9a-fA-F]+
+              where: BLOCKCHAIN = 'polygon'

--- a/models/solana/gold/solana__labels.sql
+++ b/models/solana/gold/solana__labels.sql
@@ -1,6 +1,6 @@
 {{ config(
       materialized='view',
-      tags=['snowflake', 'terra_views', 'labels', 'terra_labels', 'address_labels']  
+      tags=['snowflake', 'solana_views', 'labels', 'solana_labels', 'address_labels']  
     ) 
 }}
 
@@ -13,4 +13,4 @@ SELECT
   project_name as label, 
   address_name as address_name
 FROM {{ref('silver_crosschain__address_labels')}}
-WHERE blockchain = 'terra'
+WHERE blockchain = 'solana'

--- a/models/terra/gold/terra__labels.yml
+++ b/models/terra/gold/terra__labels.yml
@@ -10,6 +10,9 @@ models:
       - name: BLOCKCHAIN
         tests:
           - not_null
+      - name: CREATOR
+        tests: 
+          - not_null
       - name: LABEL
         tests:
           - not_null
@@ -19,3 +22,8 @@ models:
       - name: LABEL_TYPE
         tests:
           - not_null
+      - name: ADDRESS_NAME
+        description: Name of the controlling entity of the address
+        tests:
+          - not_null: 
+              enabled: False # Bug in deposit wallet algorithm causing nulls in this field


### PR DESCRIPTION
This PR adds a view of the address labels for each schema where labels are available. Tests for all views except for Solana gold (no tests turned on - labels are being tested in crosschain anyways). 

Some modifications to terra labels. Addition of "creator" column as this is part of the address_label unique key. Right now, the creator for all labels is Flipside. But in the future, data science envisions Velocity users being able to create their own labels. This would likely lead to a lot of duplication without the creator column. Added test field for address_name, but disabled test. Right now, address_name tests are disabled in ethereum and terra due to a bug in the deposit wallet algorithm.  