### PR TITLE
silver schema for solana transfers

### DIFF
--- a/models/solana/gold/solana__transfers.sql
+++ b/models/solana/gold/solana__transfers.sql
@@ -4,28 +4,21 @@
 ) }}
 
 SELECT
-    block_timestamp, 
-    block_id, 
-    blockchain, 
-    recent_block_hash, 
-    tx_id, 
-    index, 
-    event_type, 
-    preTokenBalances, 
-    postTokenBalances, 
-    instruction:parsed:info:destination :: STRING AS destination, 
-    instruction:parsed:info:source :: STRING AS source, 
-    instruction:parsed:info:authority :: STRING AS authority,
-    CASE 
-        WHEN event_type = 'transferChecked' THEN instruction:parsed:info:tokenAmount:amount/POW(10,6)
-        WHEN event_type = 'transfer' AND instruction:programId :: STRING = '11111111111111111111111111111111' THEN instruction:parsed:info:lamports/POW(10,9)
-        ELSE instruction:parsed:info:amount/POW(10,6) END
-    AS amount, 
-    instruction:programId :: STRING AS program_id, 
-    succeeded, 
-    ingested_at, 
-    CASE WHEN program_id <> 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' THEN TRUE ELSE FALSE END AS transfer_tx_flag 
-FROM {{ ref('silver_solana__events') }}
+  block_timestamp, 
+  block_id, 
+  blockchain, 
+  recent_block_hash, 
+  tx_id, 
+  succeeded, 
+  preTokenBalances, 
+  postTokenBalances, 
+  destination, 
+  source, 
+  authority, 
+  amount, 
+  event_type, 
+  instruction, 
+  ingested_at
 
-WHERE event_type = 'transfer' 
-OR event_type = 'transferChecked'
+FROM   
+    {{ ref('silver_solana__transfers') }} 

--- a/models/solana/silver/silver_solana__transfers.sql
+++ b/models/solana/silver/silver_solana__transfers.sql
@@ -1,0 +1,45 @@
+{{ config(
+  materialized = 'incremental',
+  unique_key = "CONCAT_WS('-', block_id, tx_id)",
+  incremental_strategy = 'delete+insert',
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['snowflake', 'solana', 'silver_solana', 'solana_transfers']
+) }}
+
+
+SELECT 
+  t.block_timestamp :: TIMESTAMP AS block_timestamp, 
+  t.block_id :: INTEGER AS block_id,
+  t.chain_id :: STRING AS blockchain, 
+  t.tx :transaction:message:recentBlockhash :: STRING AS recent_block_hash, 
+  t.tx_id :: STRING AS tx_id,
+  CASE WHEN t.tx :meta:status:Err IS NULL THEN TRUE ELSE FALSE END AS succeeded, 
+  t.tx :meta:preTokenBalances :: ARRAY AS preTokenBalances, 
+  t.tx :meta:postTokenBalances :: ARRAY AS postTokenBalances,   
+  i.value :parsed:info:destination :: STRING AS destination, 
+  i.value :parsed:info:source :: STRING AS source, 
+  i.value :parsed:info:authority :: STRING AS authority,
+  CASE 
+    WHEN i.event_type = 'transfer' AND i.value:programId :: STRING = '11111111111111111111111111111111' THEN i.value:parsed:info:lamports/POW(10,9)
+    ELSE i.value :parsed:info:amount/POW(10,6) END
+  AS amount,
+  i.event_type :: STRING AS event_type, 
+  i.value AS instruction, 
+  t.ingested_at :: TIMESTAMP AS ingested_at
+
+FROM {{ ref('solana_dbt__instructions') }} i
+
+LEFT OUTER JOIN {{ ref('bronze_solana__transactions') }} t 
+ON t.block_id = i.block_id 
+AND t.tx_id = i.tx_id
+
+WHERE i.event_type :: STRING = 'transfer'
+
+{% if is_incremental() %}
+  AND t.ingested_at >= getdate() - interval '2 days'
+  AND i.ingested_at >= getdate() - interval '2 days'
+{% endif %}  
+
+qualify(ROW_NUMBER() over(PARTITION BY t.block_id, t.tx_id
+ORDER BY
+  t.ingested_at DESC)) = 1

--- a/models/solana/silver/silver_solana__transfers.yml
+++ b/models/solana/silver/silver_solana__transfers.yml
@@ -1,0 +1,45 @@
+version: 2
+models:
+  - name: silver_solana__transfers
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_ID
+            - TX_ID
+    columns:
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+      - name: BLOCK_ID
+        tests:
+          - not_null
+      - name: BLOCKCHAIN 
+        tests: 
+          - not_null
+      - name: RECENT_BLOCK_HASH
+        tests:
+          - not_null
+      - name: TX_ID
+        tests:
+          - not_null
+      - name: SUCCEEDED
+        tests: 
+          - not_null
+      - name: DESTINATION
+        tests:  
+          - not_null
+      - name: SOURCE 
+        tests: 
+          - not_null
+      - name: AMOUNT
+        tests: 
+          - not_null
+      - name: EVENT_TYPE
+        tests: 
+          - not_null
+      - name: INGESTED_AT
+        tests: 
+          - not_null


### PR DESCRIPTION
This PR removes all logic from the Solana gold view of the transfers table and moves it to a new silver_solana.transfers model. Silver_solana.transfers is structured in the same manner as LP actions. 

This was done due to Velocity users complaining about the performance of transfers. 