### PR TITLE
An 684/cluster by and recency tests

### DIFF
--- a/models/algorand/gold/algorand__block.yml
+++ b/models/algorand/gold/algorand__block.yml
@@ -12,6 +12,9 @@ models:
       - name: BLOCK_TIMESTAMP
         tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
       - name: REWARDSLEVEL
         tests:
           - not_null

--- a/models/algorand/gold/algorand__transaction_participation.sql
+++ b/models/algorand/gold/algorand__transaction_participation.sql
@@ -4,6 +4,7 @@
 ) }}
 
 SELECT
+    block_timestamp,
     block_id,
     intra,
     address

--- a/models/algorand/gold/algorand__transaction_participation.yml
+++ b/models/algorand/gold/algorand__transaction_participation.yml
@@ -8,6 +8,12 @@ models:
             - INTRA
             - ADDRESS
     columns:
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
       - name: BLOCK_ID
         tests:
           - not_null

--- a/models/algorand/gold/algorand__transactions.yml
+++ b/models/algorand/gold/algorand__transactions.yml
@@ -6,6 +6,9 @@ models:
       - name: BLOCK_TIMESTAMP
         tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
       - name: BLOCK_ID
         tests:
           - not_null

--- a/models/algorand/silver/silver_algorand__asset_transfer_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_transfer_transaction.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'algorand', 'asset_transfer', 'silver_algorand_tx']
 ) }}
 

--- a/models/algorand/silver/silver_algorand__block.yml
+++ b/models/algorand/silver/silver_algorand__block.yml
@@ -12,6 +12,9 @@ models:
       - name: BLOCK_TIMESTAMP
         tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
       - name: REWARDSLEVEL
         tests:
           - not_null

--- a/models/algorand/silver/silver_algorand__payment_transaction.sql
+++ b/models/algorand/silver/silver_algorand__payment_transaction.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'algorand', 'payment', 'silver_algorand_tx']
 ) }}
 

--- a/models/algorand/silver/silver_algorand__transaction_participation.sql
+++ b/models/algorand/silver/silver_algorand__transaction_participation.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'algorand', 'transaction_participation', 'silver_algorand']
 ) }}
 
@@ -23,10 +24,11 @@ WITH inner_tx_individual AS(
     address
 )
 SELECT
-  block_id,
-  intra,
+  ab.block_timestamp AS block_timestamp,
+  iti.block_id,
+  iti.intra,
   algorand_decode_hex_addr(
-    address :: text
+    iti.address :: text
   ) AS address,
   concat_ws(
     '-',
@@ -36,7 +38,10 @@ SELECT
   ) AS _unique_key,
   _FIVETRAN_SYNCED
 FROM
-  inner_tx_individual
+  inner_tx_individual iti
+  LEFT JOIN {{ ref('silver_algorand__block') }}
+  ab
+  ON b.round = ab.block_id
 WHERE
   1 = 1
 

--- a/models/algorand/silver/silver_algorand__transaction_participation.sql
+++ b/models/algorand/silver/silver_algorand__transaction_participation.sql
@@ -32,16 +32,16 @@ SELECT
   ) AS address,
   concat_ws(
     '-',
-    block_id :: STRING,
-    intra :: STRING,
-    address :: STRING
+    iti.block_id :: STRING,
+    iti.intra :: STRING,
+    iti.address :: stringg
   ) AS _unique_key,
-  _FIVETRAN_SYNCED
+  iti._FIVETRAN_SYNCED
 FROM
   inner_tx_individual iti
   LEFT JOIN {{ ref('silver_algorand__block') }}
   ab
-  ON b.round = ab.block_id
+  ON iti.block_id = ab.block_id
 WHERE
   1 = 1
 

--- a/models/algorand/silver/silver_algorand__transaction_participation.yml
+++ b/models/algorand/silver/silver_algorand__transaction_participation.yml
@@ -8,6 +8,12 @@ models:
             - INTRA
             - ADDRESS
     columns:
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
       - name: BLOCK_ID
         tests:
           - not_null

--- a/models/algorand/silver/silver_algorand__transactions.sql
+++ b/models/algorand/silver/silver_algorand__transactions.sql
@@ -2,6 +2,7 @@
   materialized = 'incremental',
   unique_key = '_unique_key',
   incremental_strategy = 'merge',
+  cluster_by = ['block_timestamp::DATE'],
   tags = ['snowflake', 'algorand', 'transactions', 'silver_algorand_tx']
 ) }}
 

--- a/models/algorand/silver/silver_algorand__transactions.yml
+++ b/models/algorand/silver/silver_algorand__transactions.yml
@@ -10,6 +10,9 @@ models:
       - name: BLOCK_TIMESTAMP
         tests:
           - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
       - name: BLOCK_ID
         tests:
           - not_null


### PR DESCRIPTION
-Added clustering to models with more than 100M rows.
-added recency tests to blocks, transaction, and transaction participation table