### PR TITLE
missing column in gold view added

### DIFF
--- a/models/solana/gold/solana__nfts.sql
+++ b/models/solana/gold/solana__nfts.sql
@@ -14,6 +14,7 @@ SELECT
     preTokenBalances,  
     postTokenBalances, 
     instruction, 
+    inner_instruction, 
     ingested_at
 
 FROM {{ ref('silver_solana__nfts') }} 


### PR DESCRIPTION
The column "inner_instructions" was not carried from silver -> gold in the NFT table. This column contains all the pricing data for NFT sales. 

In this PR, the column is added to the gold view. 