### PR TITLE
An 746/patched algorand schemas np

### DIFF
--- a/models/algorand/silver/silver_algorand__account.sql
+++ b/models/algorand/silver/silver_algorand__account.sql
@@ -29,7 +29,7 @@ SELECT
   _FIVETRAN_SYNCED
 FROM
   {{ source(
-    'algorand',
+    'algorand_patch',
     'ACCOUNT'
   ) }}
 WHERE

--- a/models/algorand/silver/silver_algorand__account.sql
+++ b/models/algorand/silver/silver_algorand__account.sql
@@ -26,7 +26,11 @@ SELECT
   created_at AS created_at,
   keytype AS wallet_type,
   account_data AS account_data,
-  _FIVETRAN_SYNCED
+  DATEADD(
+    'MS',
+    __HEVO__LOADED_AT,
+    '1970-01-01'
+  ) AS _FIVETRAN_SYNCED
 FROM
   {{ source(
     'algorand_patch',

--- a/models/algorand/silver/silver_algorand__account_app.sql
+++ b/models/algorand/silver/silver_algorand__account_app.sql
@@ -22,7 +22,7 @@ SELECT
   _FIVETRAN_SYNCED
 FROM
   {{ source(
-    'algorand',
+    'algorand_patch',
     'ACCOUNT_APP'
   ) }}
 WHERE

--- a/models/algorand/silver/silver_algorand__account_app.sql
+++ b/models/algorand/silver/silver_algorand__account_app.sql
@@ -19,7 +19,11 @@ SELECT
     addr :: STRING,
     app :: STRING
   ) AS _unique_key,
-  _FIVETRAN_SYNCED
+  DATEADD(
+    'MS',
+    __HEVO__LOADED_AT,
+    '1970-01-01'
+  ) AS _FIVETRAN_SYNCED
 FROM
   {{ source(
     'algorand_patch',

--- a/models/algorand/silver/silver_algorand__account_asset.sql
+++ b/models/algorand/silver/silver_algorand__account_asset.sql
@@ -12,7 +12,7 @@ WITH asset_name AS (
     params :an :: STRING AS NAME
   FROM
     {{ source(
-      'algorand',
+      'algorand_patch',
       'ASSET'
     ) }}
 )
@@ -35,8 +35,7 @@ SELECT
   _FIVETRAN_SYNCED
 FROM
   {{ source(
-    'algorand',
-    'ACCOUNT_ASSET'
+    'algorand_patch' 'ACCOUNT_ASSET'
   ) }}
   aa
   LEFT JOIN asset_name an

--- a/models/algorand/silver/silver_algorand__account_asset.sql
+++ b/models/algorand/silver/silver_algorand__account_asset.sql
@@ -32,10 +32,15 @@ SELECT
     address :: STRING,
     asset_id :: STRING
   ) AS _unique_key,
-  _FIVETRAN_SYNCED
+  DATEADD(
+    'MS',
+    __HEVO__LOADED_AT,
+    '1970-01-01'
+  ) AS _FIVETRAN_SYNCED
 FROM
   {{ source(
-    'algorand_patch' 'ACCOUNT_ASSET'
+    'algorand_patch',
+    'ACCOUNT_ASSET'
   ) }}
   aa
   LEFT JOIN asset_name an

--- a/models/algorand/silver/silver_algorand__app.sql
+++ b/models/algorand/silver/silver_algorand__app.sql
@@ -17,7 +17,7 @@ SELECT
   _FIVETRAN_SYNCED
 FROM
   {{ source(
-    'algorand',
+    'algorand_patch',
     'APP'
   ) }}
 WHERE

--- a/models/algorand/silver/silver_algorand__app.sql
+++ b/models/algorand/silver/silver_algorand__app.sql
@@ -14,7 +14,11 @@ SELECT
   closed_at AS closed_at,
   created_at AS created_at,
   params,
-  _FIVETRAN_SYNCED
+  DATEADD(
+    'MS',
+    __HEVO__LOADED_AT,
+    '1970-01-01'
+  ) AS _FIVETRAN_SYNCED
 FROM
   {{ source(
     'algorand_patch',

--- a/models/algorand/silver/silver_algorand__application_call_transaction.sql
+++ b/models/algorand/silver/silver_algorand__application_call_transaction.sql
@@ -5,11 +5,11 @@
   tags = ['snowflake', 'algorand', 'application_call', 'silver_algorand_tx']
 ) }}
 
-WITH allTXN AS (
+WITH allTXN_fivetran AS (
 
   SELECT
     ab.block_timestamp AS block_timestamp,
-    b.intra,
+    b.intra AS intra,
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
@@ -49,6 +49,74 @@ WITH allTXN AS (
     ON b.round = ab.block_id
   WHERE
     tx_type = 'appl'
+),
+allTXN_hevo AS (
+  SELECT
+    ab.block_timestamp AS block_timestamp,
+    b.intra AS intra,
+    b.round AS block_id,
+    txn :txn :grp :: STRING AS tx_group_id,
+    CASE
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
+      ELSE b.txid :: text
+    END AS tx_id,
+    CASE
+      WHEN b.txid IS NULL THEN 'true'
+      ELSE 'false'
+    END AS inner_tx,
+    txn :txn :snd :: text AS sender,
+    txn :txn :fee / pow(
+      10,
+      6
+    ) AS fee,
+    txn :txn :apid AS app_id,
+    txn :txn :type :: STRING AS tx_type,
+    CASE
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
+      ELSE txn :txn :gh :: STRING
+    END AS genesis_hash,
+    txn AS tx_message,
+    extra,
+    DATEADD(
+      'MS',
+      b.__HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN'
+    ) }}
+    b
+    LEFT JOIN {{ ref('silver_algorand__inner_txids') }}
+    ft
+    ON b.round = ft.inner_round
+    AND b.intra = ft.inner_intra
+    LEFT JOIN {{ ref('silver_algorand__block') }}
+    ab
+    ON b.round = ab.block_id
+  WHERE
+    tx_type = 'appl'
+    AND b.round > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN'
+        ) }}
+    )
+),
+allTXN AS(
+  SELECT
+    *
+  FROM
+    allTXN_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    allTXN_hevo
 )
 SELECT
   block_timestamp,

--- a/models/algorand/silver/silver_algorand__asset.sql
+++ b/models/algorand/silver/silver_algorand__asset.sql
@@ -17,7 +17,11 @@ SELECT
   deleted AS asset_deleted,
   closed_at AS closed_at,
   created_at AS created_at,
-  _FIVETRAN_SYNCED
+  DATEADD(
+    'MS',
+    __HEVO__LOADED_AT,
+    '1970-01-01'
+  ) AS _FIVETRAN_SYNCED
 FROM
   {{ source(
     'algorand_patch',

--- a/models/algorand/silver/silver_algorand__asset.sql
+++ b/models/algorand/silver/silver_algorand__asset.sql
@@ -20,7 +20,7 @@ SELECT
   _FIVETRAN_SYNCED
 FROM
   {{ source(
-    'algorand',
+    'algorand_patch',
     'ASSET'
   ) }}
 WHERE

--- a/models/algorand/silver/silver_algorand__asset_configuration_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_configuration_transaction.sql
@@ -5,11 +5,11 @@
   tags = ['snowflake', 'algorand', 'asset_configuration', 'silver_algorand_tx']
 ) }}
 
-WITH allTXN AS (
+WITH allTXN_fivetran AS (
 
   SELECT
     ab.block_timestamp AS block_timestamp,
-    b.intra,
+    b.intra AS intra,
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
@@ -51,6 +51,76 @@ WITH allTXN AS (
     ON b.round = ab.block_id
   WHERE
     tx_type = 'acfg'
+),
+allTXN_hevo AS (
+  SELECT
+    ab.block_timestamp AS block_timestamp,
+    b.intra AS intra,
+    b.round AS block_id,
+    txn :txn :grp :: STRING AS tx_group_id,
+    CASE
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
+      ELSE b.txid :: text
+    END AS tx_id,
+    CASE
+      WHEN b.txid IS NULL THEN 'true'
+      ELSE 'false'
+    END AS inner_tx,
+    asset AS asset_id,
+    txn :txn :apar :t AS asset_supply,
+    txn :txn :snd :: text AS sender,
+    txn :txn :fee / pow(
+      10,
+      6
+    ) AS fee,
+    txn :txn :apar AS asset_parameters,
+    txn :txn :type :: STRING AS tx_type,
+    CASE
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
+      ELSE txn :txn :gh :: STRING
+    END AS genesis_hash,
+    txn AS tx_message,
+    extra,
+    DATEADD(
+      'MS',
+      b.__HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN'
+    ) }}
+    b
+    LEFT JOIN {{ ref('silver_algorand__inner_txids') }}
+    ft
+    ON b.round = ft.inner_round
+    AND b.intra = ft.inner_intra
+    LEFT JOIN {{ ref('silver_algorand__block') }}
+    ab
+    ON b.round = ab.block_id
+  WHERE
+    tx_type = 'acfg'
+    AND b.round > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN'
+        ) }}
+    )
+),
+allTXN AS(
+  SELECT
+    *
+  FROM
+    allTXN_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    allTXN_hevo
 )
 SELECT
   block_timestamp,

--- a/models/algorand/silver/silver_algorand__asset_freeze_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_freeze_transaction.sql
@@ -5,11 +5,11 @@
   tags = ['snowflake', 'algorand', 'asset_freeze', 'silver_algorand_tx']
 ) }}
 
-WITH allTXN AS (
+WITH allTXN_fivetran AS (
 
   SELECT
     ab.block_timestamp AS block_timestamp,
-    b.intra,
+    b.intra AS intra,
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
@@ -51,6 +51,76 @@ WITH allTXN AS (
     ON b.round = ab.block_id
   WHERE
     tx_type = 'afrz'
+),
+allTXN_hevo AS (
+  SELECT
+    ab.block_timestamp AS block_timestamp,
+    b.intra AS intra,
+    b.round AS block_id,
+    txn :txn :grp :: STRING AS tx_group_id,
+    CASE
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
+      ELSE b.txid :: text
+    END AS tx_id,
+    CASE
+      WHEN b.txid IS NULL THEN 'true'
+      ELSE 'false'
+    END AS inner_tx,
+    asset AS asset_id,
+    txn :txn :fadd :: text AS asset_address,
+    txn :txn :afrz AS asset_freeze,
+    txn :txn :snd :: text AS sender,
+    txn :txn :fee / pow(
+      10,
+      6
+    ) AS fee,
+    txn :txn :type :: STRING AS tx_type,
+    CASE
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
+      ELSE txn :txn :gh :: STRING
+    END AS genesis_hash,
+    txn AS tx_message,
+    extra,
+    DATEADD(
+      'MS',
+      b.__HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN'
+    ) }}
+    b
+    LEFT JOIN {{ ref('silver_algorand__inner_txids') }}
+    ft
+    ON b.round = ft.inner_round
+    AND b.intra = ft.inner_intra
+    LEFT JOIN {{ ref('silver_algorand__block') }}
+    ab
+    ON b.round = ab.block_id
+  WHERE
+    tx_type = 'afrz'
+    AND b.round > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN'
+        ) }}
+    )
+),
+allTXN AS(
+  SELECT
+    *
+  FROM
+    allTXN_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    allTXN_hevo
 )
 SELECT
   block_timestamp,

--- a/models/algorand/silver/silver_algorand__asset_transfer_transaction.sql
+++ b/models/algorand/silver/silver_algorand__asset_transfer_transaction.sql
@@ -6,11 +6,11 @@
   tags = ['snowflake', 'algorand', 'asset_transfer', 'silver_algorand_tx']
 ) }}
 
-WITH allTXN AS (
+WITH allTXN_fivetran AS (
 
   SELECT
     ab.block_timestamp AS block_timestamp,
-    b.intra,
+    b.intra AS intra,
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
@@ -54,6 +54,78 @@ WITH allTXN AS (
     ON b.round = ab.block_id
   WHERE
     tx_type = 'axfer'
+),
+allTXN_hevo AS (
+  SELECT
+    ab.block_timestamp AS block_timestamp,
+    b.intra AS intra,
+    b.round AS block_id,
+    txn :txn :grp :: STRING AS tx_group_id,
+    CASE
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
+      ELSE b.txid :: text
+    END AS tx_id,
+    CASE
+      WHEN b.txid IS NULL THEN 'true'
+      ELSE 'false'
+    END AS inner_tx,
+    asset AS asset_id,
+    txn :txn :snd :: text AS sender,
+    txn :txn :fee / pow(
+      10,
+      6
+    ) AS fee,
+    txn :txn :asnd :: text AS asset_sender,
+    txn :txn :arcv :: text AS asset_receiver,
+    txn :txn :aamt AS asset_amount,
+    txn :txn :xaid AS asset_transferred,
+    txn :txn :type :: STRING AS tx_type,
+    CASE
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
+      ELSE txn :txn :gh :: STRING
+    END AS genesis_hash,
+    txn AS tx_message,
+    extra,
+    DATEADD(
+      'MS',
+      b.__HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN'
+    ) }}
+    b
+    LEFT JOIN {{ ref('silver_algorand__inner_txids') }}
+    ft
+    ON b.round = ft.inner_round
+    AND b.intra = ft.inner_intra
+    LEFT JOIN {{ ref('silver_algorand__block') }}
+    ab
+    ON b.round = ab.block_id
+  WHERE
+    tx_type = 'axfer'
+    AND b.round > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN'
+        ) }}
+    )
+),
+allTXN AS(
+  SELECT
+    *
+  FROM
+    allTXN_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    allTXN_hevo
 )
 SELECT
   block_timestamp,

--- a/models/algorand/silver/silver_algorand__block.sql
+++ b/models/algorand/silver/silver_algorand__block.sql
@@ -5,25 +5,8 @@
   tags = ['snowflake', 'algorand', 'block', 'silver_algorand']
 ) }}
 
-WITH blockheader_fivetran AS(
+WITH allBLOCKS AS(
 
-  SELECT
-    ROUND AS block_id,
-    realtime :: TIMESTAMP AS block_timestamp,
-    rewardslevel AS rewardslevel,
-    header :gen :: STRING AS network,
-    header :gh :: STRING AS genesis_hash,
-    header :prev :: STRING AS prev_block_hash,
-    header :txn :: STRING AS txn_root,
-    header,
-    _FIVETRAN_SYNCED
-  FROM
-    {{ source(
-      'algorand',
-      'BLOCK_HEADER'
-    ) }}
-),
-blockheader_hevo AS(
   SELECT
     ROUND AS block_id,
     realtime :: TIMESTAMP AS block_timestamp,
@@ -43,17 +26,6 @@ blockheader_hevo AS(
       'algorand_patch',
       'BLOCK_HEADER'
     ) }}
-),
-allBLOCKS AS(
-  SELECT
-    *
-  FROM
-    blockheader_fivetran
-  UNION
-  SELECT
-    *
-  FROM
-    blockheader_hevo
 )
 SELECT
   block_id,

--- a/models/algorand/silver/silver_algorand__block.sql
+++ b/models/algorand/silver/silver_algorand__block.sql
@@ -5,21 +5,68 @@
   tags = ['snowflake', 'algorand', 'block', 'silver_algorand']
 ) }}
 
+WITH blockheader_fivetran AS(
+
+  SELECT
+    ROUND AS block_id,
+    realtime :: TIMESTAMP AS block_timestamp,
+    rewardslevel AS rewardslevel,
+    header :gen :: STRING AS network,
+    header :gh :: STRING AS genesis_hash,
+    header :prev :: STRING AS prev_block_hash,
+    header :txn :: STRING AS txn_root,
+    header,
+    _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand',
+      'BLOCK_HEADER'
+    ) }}
+),
+blockheader_hevo AS(
+  SELECT
+    ROUND AS block_id,
+    realtime :: TIMESTAMP AS block_timestamp,
+    rewardslevel AS rewardslevel,
+    header :gen :: STRING AS network,
+    header :gh :: STRING AS genesis_hash,
+    header :prev :: STRING AS prev_block_hash,
+    header :txn :: STRING AS txn_root,
+    header,
+    DATEADD(
+      'MS',
+      __HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'BLOCK_HEADER'
+    ) }}
+),
+allBLOCKS AS(
+  SELECT
+    *
+  FROM
+    blockheader_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    blockheader_hevo
+)
 SELECT
-  ROUND AS block_id,
-  realtime :: TIMESTAMP AS block_timestamp,
-  rewardslevel AS rewardslevel,
-  header :gen :: STRING AS network,
-  header :gh :: STRING AS genesis_hash,
-  header :prev :: STRING AS prev_block_hash,
-  header :txn :: STRING AS txn_root,
+  block_id,
+  block_timestamp,
+  rewardslevel,
+  network,
+  genesis_hash,
+  prev_block_hash,
+  txn_root,
   header,
   _FIVETRAN_SYNCED
 FROM
-  {{ source(
-    'algorand',
-    'BLOCK_HEADER'
-  ) }}
+  allBLOCKS
 WHERE
   1 = 1
 

--- a/models/algorand/silver/silver_algorand__inner_txids.sql
+++ b/models/algorand/silver/silver_algorand__inner_txids.sql
@@ -5,7 +5,7 @@
   tags = ['snowflake', 'algorand', 'transactions', 'all_algorand_tx']
 ) }}
 
-WITH emptyROUNDS AS (
+WITH emptyROUNDS_fivetran AS (
 
   SELECT
     ROUND,
@@ -21,7 +21,46 @@ WITH emptyROUNDS AS (
   WHERE
     txid IS NULL
 ),
-fulljson AS (
+emptyROUNDS_hevo AS (
+  SELECT
+    ROUND,
+    intra,
+    txn,
+    extra,
+    DATEADD(
+      'MS',
+      __HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN'
+    ) }}
+  WHERE
+    txid IS NULL
+    AND ROUND > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN'
+        ) }}
+    )
+),
+emptyROUNDS AS(
+  SELECT
+    *
+  FROM
+    emptyROUNDS_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    emptyROUNDS_hevo
+),
+fulljson_fivetran AS (
   SELECT
     ROUND,
     txid,
@@ -34,6 +73,40 @@ fulljson AS (
     ) }}
   WHERE
     txid IS NOT NULL
+),
+fulljson_hevo AS (
+  SELECT
+    ROUND,
+    txid,
+    intra,
+    txn :txn :gh :: STRING AS gh
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN'
+    ) }}
+  WHERE
+    txid IS NOT NULL
+    AND ROUND > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN'
+        ) }}
+    )
+),
+fulljson AS(
+  SELECT
+    *
+  FROM
+    fulljson_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    fulljson_hevo
 )
 SELECT
   f.round AS txn_round,

--- a/models/algorand/silver/silver_algorand__key_registration_transaction.sql
+++ b/models/algorand/silver/silver_algorand__key_registration_transaction.sql
@@ -5,11 +5,11 @@
   tags = ['snowflake', 'algorand', 'key_registration', 'silver_algorand_tx']
 ) }}
 
-WITH allTXN AS (
+WITH allTXN_fivetran AS (
 
   SELECT
     ab.block_timestamp AS block_timestamp,
-    b.intra,
+    b.intra AS intra,
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
@@ -54,6 +54,79 @@ WITH allTXN AS (
     ON b.round = ab.block_id
   WHERE
     tx_type = 'keyreg'
+),
+allTXN_hevo AS (
+  SELECT
+    ab.block_timestamp AS block_timestamp,
+    b.intra AS intra,
+    b.round AS block_id,
+    txn :txn :grp :: STRING AS tx_group_id,
+    CASE
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
+      ELSE b.txid :: text
+    END AS tx_id,
+    CASE
+      WHEN b.txid IS NULL THEN 'true'
+      ELSE 'false'
+    END AS inner_tx,
+    asset AS asset_id,
+    txn :txn :snd :: text AS sender,
+    txn :txn :fee / pow(
+      10,
+      6
+    ) AS fee,
+    txn :txn :votekey :: text AS participation_key,
+    txn :txn :selkey :: text AS vrf_public_key,
+    txn :txn :votefst AS vote_first,
+    txn :txn :votelst AS vote_last,
+    txn :txn :votekd AS vote_keydilution,
+    txn :txn :type :: STRING AS tx_type,
+    CASE
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
+      ELSE txn :txn :gh :: STRING
+    END AS genesis_hash,
+    txn AS tx_message,
+    extra,
+    DATEADD(
+      'MS',
+      b.__HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN'
+    ) }}
+    b
+    LEFT JOIN {{ ref('silver_algorand__inner_txids') }}
+    ft
+    ON b.round = ft.inner_round
+    AND b.intra = ft.inner_intra
+    LEFT JOIN {{ ref('silver_algorand__block') }}
+    ab
+    ON b.round = ab.block_id
+  WHERE
+    tx_type = 'keyreg'
+    AND b.round > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN'
+        ) }}
+    )
+),
+allTXN AS(
+  SELECT
+    *
+  FROM
+    allTXN_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    allTXN_hevo
 )
 SELECT
   block_timestamp,

--- a/models/algorand/silver/silver_algorand__payment_transaction.sql
+++ b/models/algorand/silver/silver_algorand__payment_transaction.sql
@@ -6,7 +6,7 @@
   tags = ['snowflake', 'algorand', 'payment', 'silver_algorand_tx']
 ) }}
 
-WITH allTXN AS (
+WITH allTXN_fivetran AS (
 
   SELECT
     ab.block_timestamp AS block_timestamp,
@@ -55,6 +55,79 @@ WITH allTXN AS (
     ON b.round = ab.block_id
   WHERE
     tx_type = 'pay'
+),
+allTXN_hevo AS (
+  SELECT
+    ab.block_timestamp AS block_timestamp,
+    b.intra,
+    b.round AS block_id,
+    txn :txn :grp :: STRING AS tx_group_id,
+    CASE
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
+      ELSE b.txid :: text
+    END AS tx_id,
+    CASE
+      WHEN b.txid IS NULL THEN 'true'
+      ELSE 'false'
+    END AS inner_tx,
+    asset AS asset_id,
+    txn :txn :snd :: text AS sender,
+    txn :txn :rcv :: text AS receiver,
+    txn :txn :amt / pow(
+      10,
+      6
+    ) AS amount,
+    txn :txn :fee / pow(
+      10,
+      6
+    ) AS fee,
+    txn :txn :type :: STRING AS tx_type,
+    CASE
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
+      ELSE txn :txn :gh :: STRING
+    END AS genesis_hash,
+    txn AS tx_message,
+    extra,
+    DATEADD(
+      'MS',
+      b.__HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN'
+    ) }}
+    b
+    LEFT JOIN {{ ref('silver_algorand__inner_txids') }}
+    ft
+    ON b.round = ft.inner_round
+    AND b.intra = ft.inner_intra
+    LEFT JOIN {{ ref('silver_algorand__block') }}
+    ab
+    ON b.round = ab.block_id
+  WHERE
+    tx_type = 'pay'
+    AND b.round > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN'
+        ) }}
+    )
+),
+allTXN AS(
+  SELECT
+    *
+  FROM
+    allTXN_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    allTXN_hevo
 )
 SELECT
   block_timestamp,

--- a/models/algorand/silver/silver_algorand__transaction_participation.sql
+++ b/models/algorand/silver/silver_algorand__transaction_participation.sql
@@ -22,6 +22,33 @@ WITH inner_tx_individual AS(
     block_id,
     intra,
     address
+),
+hevo_inner_tx_individual AS(
+  SELECT
+    ROUND AS block_id,
+    intra,
+    addr :: text AS address,
+    MIN(DATEADD('MS', __HEVO__LOADED_AT, '1970-01-01')) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN_PARTICIPATION_MISSING'
+    ) }}
+  GROUP BY
+    block_id,
+    intra,
+    address
+),
+all_inner_tx_individual AS(
+  SELECT
+    *
+  FROM
+    inner_tx_individual
+  UNION
+  SELECT
+    *
+  FROM
+    hevo_inner_tx_individual
 )
 SELECT
   ab.block_timestamp AS block_timestamp,
@@ -38,7 +65,7 @@ SELECT
   ) AS _unique_key,
   iti._FIVETRAN_SYNCED
 FROM
-  inner_tx_individual iti
+  all_inner_tx_individual iti
   LEFT JOIN {{ ref('silver_algorand__block') }}
   ab
   ON iti.block_id = ab.block_id

--- a/models/algorand/silver/silver_algorand__transaction_participation.sql
+++ b/models/algorand/silver/silver_algorand__transaction_participation.sql
@@ -34,6 +34,16 @@ hevo_inner_tx_individual AS(
       'algorand_patch',
       'TXN_PARTICIPATION_MISSING'
     ) }}
+  WHERE
+    ROUND > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN_PARTICIPATION'
+        ) }}
+    )
   GROUP BY
     block_id,
     intra,

--- a/models/algorand/silver/silver_algorand__transactions.sql
+++ b/models/algorand/silver/silver_algorand__transactions.sql
@@ -6,11 +6,11 @@
   tags = ['snowflake', 'algorand', 'transactions', 'silver_algorand_tx']
 ) }}
 
-WITH allTXN AS (
+WITH allTXN_fivetran AS (
 
   SELECT
     ab.block_timestamp AS block_timestamp,
-    b.intra,
+    b.intra AS intra,
     b.round AS block_id,
     txn :txn :grp :: STRING AS tx_group_id,
     CASE
@@ -51,6 +51,76 @@ WITH allTXN AS (
     LEFT JOIN {{ ref('silver_algorand__block') }}
     ab
     ON b.round = ab.block_id
+),
+allTXN_hevo AS (
+  SELECT
+    ab.block_timestamp AS block_timestamp,
+    b.intra AS intra,
+    b.round AS block_id,
+    txn :txn :grp :: STRING AS tx_group_id,
+    CASE
+      WHEN b.txid IS NULL THEN ft.txn_txn_id :: text
+      ELSE b.txid :: text
+    END AS tx_id,
+    CASE
+      WHEN b.txid IS NULL THEN 'true'
+      ELSE 'false'
+    END AS inner_tx,
+    CASE
+      WHEN txn :txn :type :: STRING = 'appl' THEN NULL
+      ELSE asset
+    END AS asset_id,
+    txn :txn :snd :: text AS sender,
+    txn :txn :fee / pow(
+      10,
+      6
+    ) AS fee,
+    txn :txn :type :: STRING AS tx_type,
+    CASE
+      WHEN b.txid IS NULL THEN ft.genesis_hash :: text
+      ELSE txn :txn :gh :: STRING
+    END AS genesis_hash,
+    txn AS tx_message,
+    extra,
+    DATEADD(
+      'MS',
+      b.__HEVO__LOADED_AT,
+      '1970-01-01'
+    ) AS _FIVETRAN_SYNCED
+  FROM
+    {{ source(
+      'algorand_patch',
+      'TXN'
+    ) }}
+    b
+    LEFT JOIN {{ ref('silver_algorand__inner_txids') }}
+    ft
+    ON b.round = ft.inner_round
+    AND b.intra = ft.inner_intra
+    LEFT JOIN {{ ref('silver_algorand__block') }}
+    ab
+    ON b.round = ab.block_id
+  WHERE
+    b.round > (
+      SELECT
+        MAX(ROUND)
+      FROM
+        {{ source(
+          'algorand',
+          'TXN'
+        ) }}
+    )
+),
+allTXN AS(
+  SELECT
+    *
+  FROM
+    allTXN_fivetran
+  UNION
+  SELECT
+    *
+  FROM
+    allTXN_hevo
 )
 SELECT
   block_timestamp,

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -148,9 +148,15 @@ sources:
   - name: algorand_patch
     schema: BRONZE_ALOGRAND_2_8_0__HEVO
     tables:
-      - name: TXN
-      - name: TXN_PARTICIPATION_MISSING
+      - name: ACCOUNT
+      - name: ACCOUNT_APP
+      - name: ACCOUNT_ASSET
+      - name: APP
+      - name: ASSET
       - name: BLOCK_HEADER
+      - name: TXN
+      - name: TXN_PARTICIPATION 
+      - name: TXN_PARTICIPATION_MISSING
   - name: prod
     database: chainwalkers
     schema: prod

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -150,6 +150,7 @@ sources:
     tables:
       - name: TXN
       - name: TXN_PARTICIPATION_MISSING
+      - name: BLOCK_HEADER
   - name: prod
     database: chainwalkers
     schema: prod

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -145,6 +145,9 @@ sources:
       - name: METASTATE
       - name: TXN
       - name: TXN_PARTICIPATION 
+    schema: BRONZE_ALOGRAND_2_8_0__HEVO
+      - name: TXN
+      - name: TXN_PARTICIPATION_MISSING
   - name: prod
     database: chainwalkers
     schema: prod

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -145,7 +145,9 @@ sources:
       - name: METASTATE
       - name: TXN
       - name: TXN_PARTICIPATION 
+  - name: algorand_patch
     schema: BRONZE_ALOGRAND_2_8_0__HEVO
+    tables:
       - name: TXN
       - name: TXN_PARTICIPATION_MISSING
   - name: prod


### PR DESCRIPTION
-Adding HEVO schema
-Adjusting all models (except transaction participation and the transaction models) to rely solely on HEVO schema
-TX participation, inner transaction, and transaction models rely on 2.8 up until max block and then HEVO for the rest.