### PR TITLE
remove recency test for anchor gov vote

### DIFF
--- a/models/terra/anchor/anchor__gov_vote.yml
+++ b/models/terra/anchor/anchor__gov_vote.yml
@@ -23,9 +23,6 @@ models:
         description: the timestamp this transaction get generated
         tests:
           - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
       - name: TX_ID
         description: the unique identifier to find this transaction 
         tests:


### PR DESCRIPTION
Remove recency test for anchor gov vote because the vote data is sparse.  @amasucci13 confirmed we have not missed any votes.