### PR TITLE
add post-hook to prevent uncle blocks

### DIFF
--- a/models/terra/silver/silver_terra__msg_events.sql
+++ b/models/terra/silver/silver_terra__msg_events.sql
@@ -3,7 +3,8 @@
   unique_key = "CONCAT_WS('-', chain_id, block_id, tx_id, msg_index, event_index, event_type)",
   incremental_strategy = 'delete+insert',
   cluster_by = ['block_timestamp::DATE'],
-  tags = ['snowflake', 'terra_silver', 'terra_msg_events']
+  tags = ['snowflake', 'terra_silver', 'terra_msg_events'],
+  post_hook = 'delete from {{ this }} m using ( select distinct block_id, tx_id from {{ this }} where block_timestamp::date >= current_date - 7 qualify(rank() over (partition by tx_id order by block_id desc)) > 1 ) ub where m.block_id = ub.block_id and m.tx_id = ub.tx_id and m.block_timestamp::date >= current_date - 7;'
 ) }}
 
 WITH msg_events_uncle_blocks_removed AS (

--- a/models/terra/silver/silver_terra__msgs.sql
+++ b/models/terra/silver/silver_terra__msgs.sql
@@ -3,7 +3,8 @@
   unique_key = "CONCAT_WS('-', chain_id, block_id, tx_id, msg_index)",
   incremental_strategy = 'delete+insert',
   cluster_by = ['block_timestamp::DATE'],
-  tags = ['snowflake', 'terra_silver', 'terra_msgs']
+  tags = ['snowflake', 'terra_silver', 'terra_msgs'],
+  post_hook = 'delete from {{ this }} m using ( select distinct block_id, tx_id from {{ this }} where block_timestamp::date >= current_date - 7 qualify(rank() over (partition by tx_id order by block_id desc)) > 1 ) ub where m.block_id = ub.block_id and m.tx_id = ub.tx_id and m.block_timestamp::date >= current_date - 7;'
 ) }}
 
 WITH msgs_uncle_blocks_removed AS (


### PR DESCRIPTION
- Add post hook for msgs and msg_events to remove uncle blocks that occur within a 7 day span.  From what @amasucci13 has seen, the uncle blocks should be pretty close together.  The 7 day buffer should be plenty of time to eliminate most if not all cases and reduce our need to resolve these by doing a full refresh