### PR TITLE
Incremental prices change

### DIFF
--- a/models/terra/gold/terra__oracle_prices.sql
+++ b/models/terra/gold/terra__oracle_prices.sql
@@ -20,9 +20,6 @@ WITH prices AS (
   WHERE
     asset_id = '4172'
     AND provider is not null
-{% if is_incremental() %}
-AND recorded_at >= getdate() - INTERVAL '1 days'
-{% endif %}
   GROUP BY
     1,
     2
@@ -40,9 +37,6 @@ other_prices AS (
       '7857',
       '8857'
     )
-{% if is_incremental() %}
-AND recorded_at >= getdate() - INTERVAL '1 days'
-{% endif %}
   GROUP BY
     1,
     2


### PR DESCRIPTION
Reverted incremental changes made in previous PR. The incremental logic was causing price_usd nulls due to a two hour luna price gap. 