### PR TITLE
remove to_amt null records

### DIFF
--- a/models/solana/silver/silver_solana__swaps_jupiter_dex.sql
+++ b/models/solana/silver/silver_solana__swaps_jupiter_dex.sql
@@ -320,3 +320,4 @@ FROM
     AND a2.rn = a2.max_rn
 WHERE
     a1.rn = 1
+    AND to_amt IS NOT NULL


### PR DESCRIPTION
- A very small amount of jupyter transactions do not appear to be swaps but incentive token transfers.  This aims to remove those from the swaps table.