### PR TITLE
Feature/delay seq gap test period configurable

### DIFF
--- a/macros/tests/delayed_sequence_gaps.sql
+++ b/macros/tests/delayed_sequence_gaps.sql
@@ -2,7 +2,8 @@
         table,
         partition_by,
         column,
-        delayed_column
+        delayed_column,
+        delayed_period
     ) %}
     {%- set partition_sql = partition_by | join(", ") -%}
     {%- set previous_column = "prev_" ~ column -%}
@@ -28,7 +29,7 @@
                     )
                 FROM
                     {{ this }}
-            ) - INTERVAL '15 HOURS'
+            ) - INTERVAL '{{ delayed_period }}'
     )
 SELECT
     {{ partition_sql + "," if partition_sql }}

--- a/models/terra/dbt/terra_dbt__astroport_pool_reserves.sql
+++ b/models/terra/dbt/terra_dbt__astroport_pool_reserves.sql
@@ -55,4 +55,3 @@ AND (
     {{ this }}
 )
 {% endif %}
-order by block_id asc

--- a/models/terra/dbt/terra_dbt__terraswap_pool_reserves.sql
+++ b/models/terra/dbt/terra_dbt__terraswap_pool_reserves.sql
@@ -40,4 +40,3 @@ AND (
     {{ this }}
 )
 {% endif %}
-order by block_id asc

--- a/tests/algorand/silver/silver_algorand__block__block_id-assert_no_gap.sql
+++ b/tests/algorand/silver/silver_algorand__block__block_id-assert_no_gap.sql
@@ -1,1 +1,1 @@
-{{ delayed_sequence_gaps(ref('silver_algorand__block'), [], "block_id", "_inserted_timestamp") }}
+{{ delayed_sequence_gaps(ref('silver_algorand__block'), [], "block_id", "_inserted_timestamp", "15 HOURS") }}

--- a/tests/algorand/silver/silver_algorand__transactions__intra-assert_no_gap.sql
+++ b/tests/algorand/silver/silver_algorand__transactions__intra-assert_no_gap.sql
@@ -1,1 +1,1 @@
-{{ delayed_sequence_gaps(ref('silver_algorand__transactions'), ["block_id","tx_id"], "intra", "_inserted_timestamp") }}
+{{ delayed_sequence_gaps(ref('silver_algorand__transactions'), ["block_id","tx_id"], "intra", "_inserted_timestamp", "15 HOURS") }}

--- a/tests/terra/silver/silver_terra__blocks__block_id-assert_no_gap.sql
+++ b/tests/terra/silver/silver_terra__blocks__block_id-assert_no_gap.sql
@@ -1,1 +1,1 @@
-{{ sequence_gaps(ref('silver_terra__blocks'), ["chain_id"], "block_id") }}
+{{ delayed_sequence_gaps(ref('silver_terra__blocks'), ["chain_id"], "block_id", "_inserted_timestamp", "2 HOURS") }}

--- a/tests/terra/silver/silver_terra__tax_rate__block_number-assert_no_gap.sql
+++ b/tests/terra/silver/silver_terra__tax_rate__block_number-assert_no_gap.sql
@@ -1,1 +1,1 @@
-{{ sequence_gaps(ref('silver_terra__tax_rate'), [], "block_number") }}
+{{ delayed_sequence_gaps(ref('silver_terra__tax_rate'), [], "block_number", "_inserted_timestamp", "2 HOURS") }}


### PR DESCRIPTION
- Make the delay period configurable for gap test
- Add delay gap test for `terra blocks` and `terra tax rate`
- Modify existing usages of delay gap test to use what was the hardcoded delay period
- Remove order by from `terraswap` and `astroport` dbt models