### PR TITLE
Add lag to not null checks

### DIFF
--- a/models/algorand/gold/algorand__swaps.yml
+++ b/models/algorand/gold/algorand__swaps.yml
@@ -37,17 +37,20 @@ models:
       - name: swapper
         description: "Address that initiated the swap"
         tests:
-          - not_null
+          - not_null:
+              where: BLOCK_TIMESTAMP <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
           - dbt_expectations.expect_column_value_lengths_to_equal:
               value: 58
       - name: swap_from_asset_id
         description: "Token being sent or swapped from"
         tests:
-          - not_null
+          - not_null:
+              where: BLOCK_TIMESTAMP <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
       - name: swap_from_amount
         description: "Total amount of the token sent in to initiate the swap"
         tests:
-          - not_null
+          - not_null:
+              where: BLOCK_TIMESTAMP <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
       - name: pool_address
         description: "Address of the pool the swap is coming from"
         tests:

--- a/models/algorand/silver/silver_algorand__swaps_pactfi_dex.yml
+++ b/models/algorand/silver/silver_algorand__swaps_pactfi_dex.yml
@@ -28,15 +28,18 @@ models:
           - not_null
       - name: swapper
         tests:
-          - not_null
+          - not_null:
+              where: _INSERTED_TIMESTAMP <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
           - dbt_expectations.expect_column_value_lengths_to_equal:
               value: 58
       - name: swap_from_asset_id
         tests:
-          - not_null
+          - not_null:
+              where: _INSERTED_TIMESTAMP <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')
       - name: swap_from_amount
         tests:
-          - not_null
+          - not_null:
+              where: _INSERTED_TIMESTAMP <  (CURRENT_TIMESTAMP - INTERVAL '8 HOURS')      
       - name: pool_address
         tests:
           - not_null


### PR DESCRIPTION
Updated the swapper, swap_from_asset_id, and swap_from_amount in not null check in the silver and gold swaps tables to include an eight hour lag