### PR TITLE
An 964/null threshold test

### DIFF
--- a/tests/terra/terra__swaps__price1_usd-null_threshold.sql
+++ b/tests/terra/terra__swaps__price1_usd-null_threshold.sql
@@ -1,1 +1,0 @@
-{{ null_threshold(ref('terra__swaps'), "price1_usd", 0.9) }}

--- a/tests/terra/terra__swaps__swap_pair-null_threshold.sql
+++ b/tests/terra/terra__swaps__swap_pair-null_threshold.sql
@@ -1,1 +1,0 @@
-{{ null_threshold(ref('terra__swaps'), "swap_pair", 0.8) }}

--- a/tests/terra/terra__swaps__token_1_amount-null_threshold.sql
+++ b/tests/terra/terra__swaps__token_1_amount-null_threshold.sql
@@ -1,1 +1,0 @@
-{{ null_threshold(ref('terra__swaps'), "token_1_amount", 0.9) }}

--- a/tests/terra/terra__swaps__token_1_amount_usd-null_threshold.sql
+++ b/tests/terra/terra__swaps__token_1_amount_usd-null_threshold.sql
@@ -1,1 +1,0 @@
-{{ null_threshold(ref('terra__swaps'), "token_1_amount_usd", 0.9) }}

--- a/tests/terra/terra__swaps__token_1_currency-null_threshold.sql
+++ b/tests/terra/terra__swaps__token_1_currency-null_threshold.sql
@@ -1,1 +1,0 @@
-{{ null_threshold(ref('terra__swaps'), "token_1_currency", 0.9) }}


### PR DESCRIPTION
Removed null threshold tests as these were legitimate nulls from swaps with no token_1_amount. 