### PR TITLE
AN-1083 Fix token with missing Symbol metadata

### DIFF
--- a/models/ethereum/ethereum__token_prices_hourly.sql
+++ b/models/ethereum/ethereum__token_prices_hourly.sql
@@ -11,7 +11,10 @@ WITH full_decimals AS (
   SELECT
     LOWER(address) AS contract_address,
     meta :decimals :: INT AS decimals,
-    meta :symbol :: STRING AS symbol
+    COALESCE(
+      meta :symbol :: STRING,
+      NAME
+    ) AS symbol
   FROM
     {{ ref('silver_ethereum__contracts') }}
   WHERE
@@ -169,7 +172,7 @@ FINAL AS (
     price IS NOT NULL
 )
 SELECT
-  f.HOUR,
+  f.hour,
   f.token_address,
   d.symbol,
   f.decimals,
@@ -177,7 +180,7 @@ SELECT
   f.is_imputed
 FROM
   FINAL f
-left outer join full_decimals d on d.contract_address = f.token_address
-qualify(ROW_NUMBER() over(PARTITION BY f.HOUR, f.token_address, d.symbol
+  LEFT OUTER JOIN full_decimals d
+  ON d.contract_address = f.token_address qualify(ROW_NUMBER() over(PARTITION BY f.hour, f.token_address, d.symbol
 ORDER BY
   f.decimals DESC) = 1)


### PR DESCRIPTION
We pull the symbol from the contract info using the following logic:

select *,meta :symbol :: STRING AS symbol
  FROM
    FLIPSIDE_PROD_DB.silver_ethereum.contracts
  WHERE LOWER(address) = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' 

This contact’s metadata does not contain a symbol. I added in a coalesce with the name. Also auto-formatting