### PR TITLE
add mint amount to switch_events and remove group by

### DIFF
--- a/models/thorchain/gold/thorchain__switch_events.sql
+++ b/models/thorchain/gold/thorchain__switch_events.sql
@@ -10,6 +10,7 @@ SELECT
   bl.height AS block_id,
   e.burn_asset,
   e.burn_e8,
+  e.mint_e8,
   e.to_addr AS to_address,
   e.from_addr AS from_address,
   e.tx
@@ -19,11 +20,3 @@ FROM
   INNER JOIN {{ ref('silver_thorchain__block_log') }}
   bl
   ON bl.timestamp = e.block_timestamp
-GROUP BY
-  block_timestamp,
-  block_id,
-  burn_asset,
-  burn_e8,
-  to_address,
-  tx,
-  from_address

--- a/models/thorchain/gold/thorchain__upgrades.sql
+++ b/models/thorchain/gold/thorchain__upgrades.sql
@@ -29,7 +29,15 @@ SELECT
   burn_e8 / pow(
     10,
     8
-  ) * rune_usd AS rune_amount_usd
+  ) * rune_usd AS rune_amount_usd,
+  mint_e8 / pow(
+    10,
+    8
+  ) AS mint_amount,
+  mint_e8 / pow(
+    10,
+    8
+  ) * rune_usd AS mint_amount_usd
 FROM
   {{ ref('thorchain__switch_events') }}
   se

--- a/models/thorchain/gold/thorchain__upgrades.yml
+++ b/models/thorchain/gold/thorchain__upgrades.yml
@@ -30,3 +30,10 @@ models:
         tests:
           - not_null:
               where: BLOCK_TIMESTAMP <= SYSDATE() - interval '2 day' AND BLOCK_TIMESTAMP >= '2021-04-13'
+      - name: MINT_AMOUNT
+        tests:
+          - not_null
+      - name: MINT_AMOUNT_USD
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP <= SYSDATE() - interval '2 day' AND BLOCK_TIMESTAMP >= '2021-04-13'

--- a/models/thorchain/silver/silver_thorchain__switch_events.yml
+++ b/models/thorchain/silver/silver_thorchain__switch_events.yml
@@ -17,3 +17,6 @@ models:
       - name: BURN_E8
         tests:
           - not_null
+      - name: MINT_E8
+        tests:
+          - not_null


### PR DESCRIPTION
THORChain is about to create a "kill switch" where the mint amount for upgrades will no longer be the same as the burn amount, so adding that column into the upgrades table.

Also removing the group by for that table since we now have the de-duping logic in place for that table.